### PR TITLE
refactor README: lead with capabilities and PM workflow, not personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,16 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Opus](https://img.shields.io/badge/Model-Opus_4.6-orange)](https://www.anthropic.com/claude)
 [![Plugins](https://img.shields.io/badge/Plugins-5-green)](#what-you-get)
-[![Skills](https://img.shields.io/badge/Skills-20+-green)](#20-codified-skills)
+[![Skills](https://img.shields.io/badge/Skills-20+-green)](#codified-skills)
 [![CI](https://img.shields.io/badge/CI-10_checks-brightgreen)](.github/workflows/validate-plugins.yml)
 
-**A Claude Code quality pipeline — named reviewer personas, three-tier delegation, and structured workflows that catch issues before they ship.**
+**A Claude Code plugin system that turns human-AI collaboration into a structured PM-EM partnership — with research pipelines, multi-session continuity, and quality gates that go beyond what's available out of the box.**
 
-**22 skills · 19 commands · 6 named reviewers · 5 domain plugins · 3 research pipelines**
-
-A Claude Code plugin that mirrors a PM-EM dynamic: you're the PM (product manager), Claude is the EM (engineering manager). The coordinator dispatches work to specialized agents across Opus/Sonnet/Haiku tiers, routes code reviews through a structured review pipeline with named personas, manages session continuity, and runs deep research pipelines — without being hamstrung by excessive guardrails or losing context across sessions.
-
-> This isn't another "AI assistant" wrapper. It's an organizational model for human-AI collaboration — a bridge crew, not a chatbot. You set the heading; the coordinator makes it so.
+> This isn't another "AI assistant" wrapper. It's an organizational model for working with Claude Code at scale — across sessions, across domains, across days. You set the heading; the coordinator makes it so.
 
 ---
 
-**Contents:** [Landscape](#where-this-sits-in-the-landscape) · [What You Get](#what-you-get) · [EM Model](#the-em-model-and-its-honest-limits) · [Quick Start](#quick-start) · [Customization](#customization) · [Architecture](#architecture) · [Credits](#credits--acknowledgments) · [License](#license)
+**Contents:** [Why This Exists](#why-this-exists) · [What's Genuinely Different](#whats-genuinely-different) · [What You Get](#what-you-get) · [How a PM Uses This](#how-a-pm-uses-this) · [Quick Start](#quick-start) · [Customization](#customization) · [Architecture](#architecture) · [Credits](#credits--acknowledgments) · [License](#license)
 
 **Quick install:**
 ```bash
@@ -26,11 +22,20 @@ cd coordinator-claude && bash setup/install.sh
 ```
 Then start Claude Code and run `/session-start`. See [Getting Started](docs/getting-started.md) for detailed setup.
 
-## Where This Sits in the Landscape
+## Why This Exists
 
-As of mid-2026, the individual techniques here — CLAUDE.md project instructions, specialized subagents, review pipelines, model tiering, persistent memory, plan-before-execute workflows — are all established patterns in the Claude Code ecosystem and the broader agentic engineering community.
+Claude Code out of the box is powerful but stateless. Each session starts cold. Research means a single web search or tool call. Reviews are one-pass. There's no structured way to hand work from Tuesday's session to Wednesday's, no way to run a multi-source research campaign, and no model for deciding what *Claude* should own versus what *you* should own.
 
-What's less common is the specific combination. A [systematic novelty assessment](docs/research/2026-03-20-agent-orchestration-novelty-unified.md) (55+ sources, 9 patterns) found three patterns with no documented prior art:
+This plugin system addresses those gaps:
+
+- **Research that actually researches.** Multi-agent pipelines that fan out across sources, cross-verify, and synthesize — not a single search call hoping for the best.
+- **Sessions that remember.** Structured handoffs that carry state, decisions, and unfinished obligations across sessions — triggered deliberately, not magically.
+- **A division of labor.** A PM-EM model where Claude has standing authority over implementation and orchestration, but product decisions stay with you.
+- **Quality gates with teeth.** Sequential review pipelines where findings must be fixed before the next reviewer sees the artifact — not parallel reviews that get summarized into a suggestions list.
+
+## What's Genuinely Different
+
+The individual techniques here — subagents, review pipelines, model tiering, project instructions — are established patterns. What's less common is the combination. A [systematic novelty assessment](docs/research/2026-03-20-agent-orchestration-novelty-unified.md) (55+ sources, 9 patterns) found three patterns with no documented prior art:
 
 1. **Cognitive tiering** — Different model tiers doing fundamentally different *types* of cognitive work (Haiku verifies, Sonnet executes, Opus judges), not the same work at different capability levels. A [2026 academic survey](https://arxiv.org/html/2603.04445) explicitly identifies this as a research gap.
 
@@ -38,34 +43,35 @@ What's less common is the specific combination. A [systematic novelty assessment
 
 3. **PM/EM authority partitioning (First Officer Doctrine)** — Standing role-level domain authority between human and AI that persists across sessions. The [National Academies](https://nap.nationalacademies.org/read/26355/chapter/4) identified persistent human-AI relationships as an explicit research gap.
 
-Three more patterns represent novel applications of known principles (character personas in engineering review, selective tool withholding, plugin-based capability composition), and the **tiered context injection** system ("warm RAM") was found to be compositionally novel across [87 surveyed sources](docs/research/2026-03-20-agent-orchestration-novelty-unified.md#appendix-warm-ram--tiered-context-injection-research).
-
-Named reviewer personas work not because of the names, but because [rich behavioral descriptions genuinely steer model behavior](docs/research/2026-03-19-named-persona-performance.md) through training data cluster activation — confirmed causally by Anthropic's persona vectors research. The names are convenience handles for humans; the descriptions are the active ingredient.
+The **tiered context injection** system ("warm RAM") was found to be compositionally novel across [87 surveyed sources](docs/research/2026-03-20-agent-orchestration-novelty-unified.md#appendix-warm-ram--tiered-context-injection-research).
 
 For context on the broader landscape: [Bassim Eledath's 8 Levels of Agentic Engineering](https://www.bassimeledath.com/blog/levels-of-agentic-engineering), [Addy Osmani on Agentic Engineering](https://addyosmani.com/blog/agentic-engineering/), and [Mike Mason on Coherence Through Orchestration](https://mikemason.ca/writing/ai-coding-agents-jan-2026/) are good reference points.
 
 ## What You Get
 
-### Named Reviewer Personas
+### Deep Research Pipelines
 
-Six specialized reviewers with distinct expertise and standards:
-- **Patrik** — Senior engineer. Rigorous code review, architecture, documentation completeness
-- **Zolí** — Ambition advocate. Challenges conservative recommendations ("should we be more ambitious?")
-- **Sid** — Game developer. Unreal Engine systems, gameplay mechanics, Blueprint/C++
-- **Palí** — Frontend specialist. Design tokens, component patterns, CSS architecture
-- **Fru** — UX reviewer. Trust signals, user flow clarity, interface intuition
-- **Camelia** — Data scientist. ML, statistics, data modeling, LLM workflows
+Three research modes that go well beyond a single search call:
 
-These aren't just labels — each persona has [research-backed behavioral descriptions](docs/research/2026-03-19-named-persona-performance.md) that measurably change review output quality. The names are stable pointers for human calibration; the descriptions are the active ingredient.
+- **Pipeline A (Codebase Research):** Haiku scouts fan out across a repository, Sonnet analysts synthesize findings, Opus judges quality. Produces an evergreen assessment of a repo's architecture, patterns, and design decisions — with an optional comparison phase that diffs the assessment against your own project. You can re-run the comparison cheaply as your project evolves without re-researching the reference.
 
-### Deep Research Pipeline
+- **Pipeline B (Internet Research):** Multi-source web research with cross-verification and source grading. What standard Claude search gives you in one call, this gives you with multiple agents verifying against each other. The difference is the difference between "I found one page that says X" and "three independent sources agree on X, one disagrees, here's why."
 
-Three research modes, all multi-agent with quality gates:
-- **Pipeline A (Codebase):** Haiku scouts fan out across a repository, Sonnet analysts synthesize findings, Opus judges quality
-- **Pipeline B (Internet):** Multi-source web research with cross-verification and source grading
-- **Pipeline C (Structured Batch):** Schema-driven research across N entities (companies, tools, teams) with repeating structure
+- **Pipeline C (Structured Batch Research):** Schema-driven research across N entities (companies, tools, teams) with a repeating structure. Input is a spec file declaring subjects, topics, acceptance criteria, and output schema. Output is structured data conforming to the schema — not prose. Supports incremental campaigns across sessions: research 5 subjects today, resume with the next 5 tomorrow, and the manifest tracks what's done and what's pending.
 
-Fast, cheap, and high-quality. What would take a human researcher hours runs in minutes.
+### NotebookLM Research Integration
+
+Research on content Claude can't access directly — YouTube videos, podcasts, audio — via Google NotebookLM. An Opus orchestrator designs research questions with baked-in anti-hallucination techniques, then dispatches a Sonnet worker for the mechanical MCP operations. The result is a polished research document with citations, gaps, and source assessment. Supports targeted mode (you provide URLs), exploratory mode (NotebookLM discovers content via Google search), and hybrid (seed URLs + gap-filling discovery).
+
+### Session Continuity
+
+This is deliberate, not automatic. Nothing persists "for free" — continuity is a PM decision, triggered when you need it:
+
+- **`/handoff`** — Structured state capture when a work cycle needs to continue in a new session. Captures what was accomplished, current state, in-progress work, key decisions with reasoning, blockers, and recommended next steps. Each handoff chains to its predecessor (anti-amnesia links), and unresolved obligations cascade forward until completed or explicitly dismissed — they can't be silently dropped.
+- **`/session-start`** — Picks up handoffs, loads project context, surfaces what needs attention. Sub-second orientation with full project awareness.
+- **`/session-end`** — Clean wrap-up: capture lessons, align docs, commit.
+
+**When handoffs happen:** (1) Context is getting long and the session needs to continue elsewhere. (2) Work is blocked on something external — a deploy, a review, a decision from someone else. (3) The PM's time is ending but the work isn't done. The PM decides when to trigger a handoff; the coordinator captures the state faithfully.
 
 ### Three-Tier Delegation
 
@@ -74,44 +80,48 @@ The right model for the right task:
 - **Sonnet** executes — code implementation, enrichment, research synthesis
 - **Haiku** verifies — mechanical checks, template validation, compile verification
 
-### Session Continuity
+### The PM-EM Model
 
-Never lose context:
-- **Handoffs** — structured state capture between sessions
-- **Orientation cache** — sub-second session start with full project awareness
-- **Memory system** — persistent knowledge across conversations
-- **Project trackers** — workstream-level progress tracking with archive conventions
+You're the PM (product manager). Claude is the EM (engineering manager). This isn't metaphorical — it's an enforced division of authority:
+
+**The EM handles autonomously:** implementation approach, file structure, delegation decisions, bug diagnosis, when to dispatch subagents, which reviewer to route to, housekeeping.
+
+**Shared decisions (EM flags, you align):** scope changes, architectural tradeoffs with product implications, anything that changes what the user sees.
+
+**PM calls (EM asks, doesn't assume):** product direction, prioritization between competing goals, external-facing actions (pushing, PRs, messages).
+
+This means the coordinator doesn't ask you *how* to implement something — it asks you *what* to build and *whether* the tradeoffs are acceptable. The implementation is the EM's domain.
+
+### Review Pipeline
+
+Code reviews route through specialized reviewer personas — senior engineer, ambition advocate, frontend specialist, UX reviewer, data scientist, game developer — each with [research-backed behavioral descriptions](docs/research/2026-03-19-named-persona-performance.md) that measurably change review output quality. Reviews are sequential with mandatory fix gates: the domain expert reviews first, findings are applied, then the generalist reviews the clean artifact. See [the plugin docs](plugins/coordinator/README.md) for the full roster.
 
 ### CI Pipeline for Prompts
 
-10 validation checks that treat behavioral specs like code:
-- Frontmatter validation, cross-reference checking, inventory counts
-- Secret detection, file size limits, agent tool consistency
-- Broken link detection, spec line count ceilings
+10 validation checks that treat behavioral specs like code: frontmatter validation, cross-reference checking, inventory counts, secret detection, file size limits, agent tool consistency, broken link detection, spec line count ceilings.
 
-### Session Lifecycle Commands
+### Codified Skills
+
+20+ tested behavioral protocols — from brainstorming to debugging to code review to git workflow. Not suggestions; enforced workflows with checklists. The coordinator follows the protocol when a skill exists rather than improvising.
+
+### Workday Commands
 
 Slash commands that structure your workday:
-- `/session-start` — Orient a new session: load context, check handoffs, surface what needs attention
-- `/session-end` — Wrap up cleanly: capture lessons, align docs, commit
-- `/handoff` — Save session state so the next session picks up where you left off
 - `/workday-start` — Morning orientation: triage handoffs, surface staleness, align priorities
 - `/workday-complete` — End of day: documentation sweep, branch consolidation, health survey
 - `/merge-to-main` — Supervised merge: create PR, gate on CI, merge, clean up
 
-These aren't ceremonial — they're the connective tissue that makes multi-session work feel continuous rather than amnesiac.
+## How a PM Uses This
 
-### 20+ Codified Skills
+**Starting a day:** Run `/workday-start`. The coordinator triages any handoffs from previous sessions, surfaces stale work, and aligns on priorities. You decide what to work on; the coordinator figures out how.
 
-From brainstorming to debugging to code review to git workflow — tested behavioral protocols that shape how the coordinator approaches work. Not suggestions; enforced workflows. The coordinator doesn't improvise when a skill exists — they follow the checklist, like any good officer would.
+**During a session:** Give direction. "Build the auth flow." "Research how competitors handle rate limiting." "Review the PR." The coordinator plans, dispatches agents, routes reviews, and reports back. You make product calls; the coordinator makes engineering calls.
 
-## The EM Model (and Its Honest Limits)
+**Ending a session:** If work is mid-flight, run `/handoff`. The coordinator captures everything the next session needs to pick up cleanly — what was done, what's in progress, what decisions were made and why, what's blocked. If work is complete, `/session-end` wraps up cleanly.
 
-The coordinator's primary mode is **engineering manager**: they plan work, dispatch agents, route reviews, verify output, and manage state. The PM sets the course; the coordinator runs the ship.
+**Research:** `/deep-research` for codebase or internet research. `/structured-research` for batch campaigns with structured output. `/notebooklm-research` for video/audio/podcast content. These aren't thin wrappers around a search API — they're multi-agent pipelines with quality gates.
 
-In practice, the coordinator *can* and sometimes *does* write code directly — particularly when dispatching an executor would spend more tokens and time than just handling it in context. This is a pragmatic tradeoff, not a hard architectural boundary. The system is designed to *encourage* delegation (and the coordinator will dispatch mechanical tasks to executors more often than not), but it isn't *enforced* — because the only way to make delegation deterministic would be to hamstring the coordinator, and we'd rather have a capable agent who occasionally does too much themselves than a restricted one who can't act when action is the right call.
-
-If you want stricter separation, you can tighten the instructions in your CLAUDE.md. We chose the flexible version.
+**The key difference from vanilla Claude Code:** You're not managing an assistant. You're managing an engineering function. The coordinator has its own judgment, its own delegation authority, and its own quality standards. Your job is product direction, prioritization, and the calls that only a human can make.
 
 ## Quick Start
 
@@ -119,7 +129,7 @@ If you want stricter separation, you can tighten the instructions in your CLAUDE
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
 - A Claude API key or Claude Pro/Team subscription
-- **Opus as the coordinator model.** The orchestration layer — plan decomposition, review judgment, delegation decisions, quality gates — is designed for Opus-level reasoning. Substituting Sonnet or below for the coordinator is a [tribble problem](https://en.wikipedia.org/wiki/The_Trouble_with_Tribbles): it'll look like it's working until the tribbles are everywhere. Each individual judgment call degrades subtly — wrong delegation, shallow review, missed quality gates — and they compound. Sonnet and Haiku are used extensively *within* the pipeline (executors, verifiers), but the coordinator itself needs Opus. Set it with `/model opus` or in your Claude Code settings.
+- **Opus as the coordinator model.** The orchestration layer — plan decomposition, review judgment, delegation decisions, quality gates — is designed for Opus-level reasoning. Sonnet and Haiku are used extensively *within* the pipeline (executors, verifiers), but the coordinator itself needs Opus. Set it with `/model opus` or in your Claude Code settings.
 
 ### Installation
 
@@ -146,8 +156,8 @@ See [docs/getting-started.md](docs/getting-started.md) for the full installation
 
 ## Customization
 
-- **Rename personas** — or keep them. The behavioral descriptions are what matter, not the names
-- **Add domain plugins** — game-dev is included as an example; create your own for your domain
+- **Add domain plugins** — game-dev, data-science, and web-dev are included; create your own for your domain
+- **Rename or modify reviewer personas** — the behavioral descriptions are what matter, not the names
 - **Write new skills** — the `coordinator:writing-skills` skill guides you through TDD for skill authoring
 - **Configure per-project** — `.claude/coordinator.local.md` controls which domain plugins activate
 
@@ -159,7 +169,7 @@ See [docs/customization.md](docs/customization.md) for details.
 You (PM) <-> Coordinator (EM)
                 |- Enricher agents (Sonnet) -- research, fill specs
                 |- Executor agents (Sonnet) -- implement from specs
-                |- Reviewer personas (Opus) -- Patrik, Camelia, Sid, Palí, Fru
+                |- Reviewer personas (Opus) -- domain-specialized review
                 |- Verification agents (Haiku) -- mechanical checks
                 `- Research orchestrators (Opus) -- deep research pipelines
 ```


### PR DESCRIPTION
Restructure to address what matters to someone evaluating the repo:
- Lead with "Why This Exists" — gaps in vanilla Claude Code
- Elevate deep research and NotebookLM as genuine differentiators
- Reframe session continuity as deliberate PM decisions (not magic)
- Add "How a PM Uses This" narrative walkthrough
- Move persona roster to a link rather than frontloading names
- Position against standard Claude Code tools throughout

https://claude.ai/code/session_01VWzxMBzHnWRtnVykbrusv7