### PR TITLE
README overhaul: feature reranking, Agent Teams headline, installer-first setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,46 @@
 # coordinator-claude — A Structured Workflow System for Claude Code
 
-A plugin set that turns Claude Code into a small engineering team: a coordinator that delegates, named specialists that review, and codified skills that encode best practices. You play PM; Claude plays EM.
+A plugin set that turns Claude Code into a small engineering team: a coordinator that delegates, persona-based specialists that review, and codified skills that encode best practices — with structured session handoffs that fight context loss. You play PM; Claude plays EM.
 
 ## What This Does
 
-Every pattern here — multi-agent orchestration, quality gates, model tiering, hooks-based context injection — exists elsewhere in the Claude Code ecosystem. The individual pieces aren't new. What's unusual is combining all of Claude Code's extension primitives (hooks, subagents, skills, commands, Agent Teams, MCP servers) into one coherent workflow stack, including early adoption of [Agent Teams](https://code.claude.com/docs/en/agent-teams) (still experimental and gated) as a first-class primitive for collaborative planning and research.
+This combines all of Claude Code's extension primitives (hooks, subagents, skills, commands, Agent Teams, MCP servers) into one coherent workflow stack. The individual patterns — multi-agent orchestration, quality gates, model tiering — exist elsewhere in the ecosystem; what's unusual is the integration and what it's used for.
 
-Three things are particularly distinctive within the Claude Code plugin ecosystem:
+Five things are particularly distinctive, ordered by impact:
 
-- **PM/EM authority partitioning.** Not "planner/coder/reviewer" — a persistent product-management authority split where the human owns product direction and the AI owns engineering execution, with explicit boundaries that carry across sessions.
+- **Agent Teams for research and planning, not just "build together."** Claude Code's [Agent Teams](https://code.claude.com/docs/en/agent-teams) (still experimental) enables multiple Claude sessions that communicate via messaging and coordinate via shared task lists. Most early adopters use it for collaborative coding — "you're a dev team, build this feature together." This system uses it differently: for **structured research** and **multi-perspective planning**. Three research pipelines (internet, repository, structured/schema-conforming) follow a tiered pattern — Haiku scouts gather sources cheaply, Sonnet specialists analyze and cross-pollinate findings via messaging, an Opus synthesizer produces the final document. **Staff sessions** use the same infrastructure for planning: persona-based debaters form independent positions, challenge each other, converge, and a synthesizer cross-references their positions into a consensus plan with noted dissent. In both cases, the coordinator scopes the work, spawns the team, and is freed — the team runs autonomously. This keeps research and planning work out of the coordinator's context window entirely, and we believe (though haven't yet proven) that specialist teams produce better research and plans than a single Claude session doing everything alone. We are [actively researching this question](docs/research/).
 
-- **Sequential review with mandatory fix gates.** Domain expert reviews first, all fixes applied, *then* the generalist reviews a clean artifact. Most tools use parallel-aggregate or single-pass review. This enforced sequencing is uncommon.
+- **Layered project knowledge, not bulk injection.** Most AI coding tools solve codebase orientation with a repo map — a structural index injected at the start of every interaction. This system maintains five complementary knowledge layers (structure, architecture, activity, intent, state), none loaded in bulk. An 11-phase maintenance pipeline fights doc staleness automatically, and the resulting documentation doubles as "grep bait" — searchable surface area that makes even vague directives land hits across plans, archives, and trackers. See the [full breakdown below](#project-knowledge-layered-context-not-bulk-injection).
 
-- **Agent Teams for collaborative planning.** Staff sessions where persona agents debate plans in parallel via Agent Teams messaging, then a synthesizer cross-references positions. Distinct from using Agent Teams for simple task fan-out.
+- **Prospective handoff artifacts for session continuity.** Long-running work in Claude Code faces a hard constraint: context compaction. When triggered, the model summarizes what it *believes* happened — a retrospective reconstruction that loses intent, momentum, and forward direction. This system takes a different approach: before compaction can fire, a `UserPromptSubmit` hook monitors estimated context usage and prompts the agent to create a structured **handoff artifact** — a *prospective* document that captures decisions made, state reached, and explicit next steps for the successor session. The handoff is a baton, not a police report. Each artifact carries forward unresolved items from its predecessor (cascade obligation) and opens with a synthesis of the prior handoff (anti-amnesia chain), making any single handoff a self-contained orientation point. A `PreCompact` hook provides a recovery bridge if the advisory is ignored. See our [handoff vs. compaction research](docs/research/2026-03-21-handoff-artifacts-vs-compaction.md) — the evidence from ACON benchmarks, Sourcegraph's production experience, and framework convergence (OpenAI, LangGraph, CrewAI) strongly favors structured handoffs over automatic summarization for chained agent work.
 
-For a deeper assessment, see the [novelty research doc](docs/research/2026-03-20-agent-orchestration-novelty-unified.md).
+- **Inverted capability delegation.** Most multi-agent systems give subagents *fewer* tools than the orchestrator — scoped-down workers executing within the coordinator's capabilities. This system deliberately inverts that. The orchestrator sees only ~8 thin MCP tools; domain subagents access 40+ tools via a proxy with full schemas loaded in fresh context. The orchestrator is *intentionally less capable* than its delegates for domain work. This saves ~40K tokens of MCP schemas from the orchestrator's context window — tokens better spent on judgment than on tool definitions — and forces delegation by design, not just by convention. A `PreToolUse` hook nudges the orchestrator to delegate when it reaches for domain tools directly. Microsoft recommends [least-privilege for agent design](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/architecture/baseline-openai-e2e-chat#security); this system applies the same principle in the opposite direction — giving the *coordinator* the minimal toolset while delegates get the full capability surface. The holodeck-control plugin (an Unreal Engine editor MCP system, not included in this repo) is the reference implementation; the pattern is general and replicable with any large MCP toolset.
+
+- **Persona-based sequential review.** Reviewer agents carry rich behavioral profiles (not just role labels like "code reviewer"), and the system enforces sequential review with mandatory fix gates — domain expert first, all findings applied, then generalist reviews a clean artifact. Research supports both the [persona mechanism](docs/research/2026-03-19-named-persona-performance.md) and the [multi-agent review gains](https://link.springer.com/article/10.1007/s10462-024-11097-3).
+
+For a deeper assessment of all patterns, see the [novelty research doc](docs/research/2026-03-20-agent-orchestration-novelty-unified.md).
 
 ## The Organizational Metaphor
 
-The system borrows from engineering management practice:
+The system borrows from engineering management practice. You sit in the captain's chair:
 
 | Role | Who | Responsibility |
 |------|-----|---------------|
-| **PM (Captain)** | Dónal | Vision, priorities, judgment calls, design approval |
+| **PM (Captain)** | You | Vision, priorities, judgment calls, design approval |
 | **EM / Coordinator (First Officer)** | Claude (main session) | Orchestration, delegation, spec compliance, pipeline flow |
 | **Executor** | Claude (subagent, Sonnet) | Faithful implementation of well-specified work |
-| **Reviewers** | Claude (subagents, Opus) | Code quality, UX, domain expertise — each with a named identity and perspective |
+| **Reviewers** | Claude (subagents, Opus) | Code quality, UX, domain expertise — each with a rich behavioral profile and adversarial framing |
 
-This is the "First Officer Doctrine" — Claude operates as EM to Dónal's PM. The EM executes with ambition, counsels honestly when they disagree, and clarifies scope when it's ambiguous. Silent compliance into a bad outcome is a failure of the role.
+This is the "First Officer Doctrine" — Claude operates as your EM (engineering manager), you operate as PM (product manager). The EM executes with ambition, counsels honestly when they disagree, and clarifies scope when it's ambiguous. Silent compliance into a bad outcome is a failure of the role. The boundary is explicit: the PM owns *what* to build and *whether* to ship; the EM owns *how* to build it and *whom* to delegate to.
 
 ## Plugins
 
 | Plugin | Purpose | When to Enable |
 |--------|---------|----------------|
-| **[coordinator](plugins/coordinator/)** | Core orchestration pipeline, universal reviewers, all workflow skills | Always |
-| **[game-dev](plugins/game-dev/)** | Sid (Unreal Engine specialist) | Unreal Engine projects |
-| **[web-dev](plugins/web-dev/)** | Pali (front-end architecture) + Fru (UX flow review) | Web projects |
-| **[data-science](plugins/data-science/)** | Camelia (ML, statistics, data modeling) | ML/data work |
+| **[coordinator](plugins/coordinator/)** | Core orchestration pipeline, reviewers, all workflow skills | Always |
+| **[game-dev](plugins/game-dev/)** | Unreal Engine specialist (architecture, C++/Blueprint) | Unreal Engine projects |
+| **[web-dev](plugins/web-dev/)** | Front-end architecture review + UX flow review | Web projects |
+| **[data-science](plugins/data-science/)** | ML, statistics, data modeling review | ML/data work |
 | **[deep-research](plugins/deep-research/)** | Multi-agent research pipelines (internet, repo, structured) | Research tasks |
 | **[notebooklm](plugins/notebooklm/)** | NotebookLM integration — YouTube, podcast, audio research via MCP | Media research (enable on demand) |
 
@@ -50,119 +54,149 @@ A typical feature goes through these stages:
 
 ```
 Brainstorm  →  Plan  →  Execute  →  Review  →  Ship
-   (skill)    (skill     (executor    (Patrik     (finish
-               or staff   agents)     + domain     branch)
-               session)               reviewers)
+   (skill)    (skill     (executor    (domain       (finish
+               or staff   agents)     → generalist   branch)
+               session)               sequential)
 ```
 
 The **Plan** stage has two paths:
 - **EM writes plan** → single-reviewer dispatch (lightweight, existing flow)
-- **Staff session** → parallel debate between staff engineers (Patrik + Zoli, or domain experts) who craft the plan collaboratively via Agent Teams. The EM writes objectives; the team writes the blueprint.
+- **Staff session** → parallel debate between persona-based staff engineers who craft the plan collaboratively via Agent Teams. The EM writes objectives; the team writes the blueprint.
 
 Each stage is a codified skill or command. The coordinator orchestrates transitions between stages and verifies output at each checkpoint.
 
-## Context Injection: Tiered "Warm RAM"
+## Customization
 
-The coordinator uses three tiers of context, not bulk injection:
+The system is designed to be adapted, not just adopted:
+
+- **Rename personas.** The reviewer names are labels; behavioral descriptions are the active ingredient. `bash setup/rename-personas.sh Patrik "Alex" Zolí "Jordan"` renames display names across all plugin files.
+- **Create your own domain reviewer.** The game-dev plugin is a reference implementation. Follow the same structure (agent file + routing fragment) to create a reviewer for any specialization — security, mobile, DevOps, etc.
+- **Per-project configuration.** Create `.claude/coordinator.local.md` in your project root to set `project_type` (web, data-science, game) and control which reviewers activate.
+
+See [docs/customization.md](docs/customization.md) for templates, the full persona registry, and instructions for adding skills and CI checks.
+
+## Project Knowledge: Layered Context, Not Bulk Injection
+
+Most AI coding tools solve the "large codebase" problem by building a repo map — a structural index of files, classes, and functions — and injecting it (or retrieving from it) at the start of every interaction. Aider pioneered this pattern; many tools have followed. It works, but it has a ceiling: a repo map tells you *what exists*, not *why it exists*, *what state it's in*, or *what to do next*.
+
+This system takes a different approach. Instead of one large artifact, it maintains several complementary knowledge layers, each serving a different purpose:
+
+| Layer | Artifact | What It Captures | How It's Maintained |
+|-------|----------|-----------------|-------------------|
+| **Structure** | `DIRECTORY.md` | File-by-file index with purpose annotations | Auto-generated, updated by `/update-docs` when source files change |
+| **Architecture** | Architecture atlas (`tasks/architecture-atlas/`) | System boundaries, connectivity, health scores | Multi-agent audit pipeline; weekly rotation targets stalest system |
+| **Activity** | Repo map (`.claude/repomap.md`) | Git-activity-ranked file list, fitted to token budget | Generated on demand; ranked by churn, not just existence |
+| **Intent** | Project tracker, roadmaps, plan docs | What's being built, what's blocked, what shipped | PM-maintained with EM assistance; `/update-docs` syncs status |
+| **State** | Health ledger, bug/debt backlogs | Known issues, sweep results, system health | Updated by sweeps and audits; surfaced at session start |
+
+None of these are loaded in bulk. Instead, the system uses a **tiered context model**:
 
 ```
-L1 (always loaded)    CLAUDE.md + MEMORY.md + orientation cache (~200 lines)
-L2 (on-demand)        DIRECTORY.md, health ledger, repomap, architecture atlas
-L3 (deep storage)     Codebase, git history — read by subagents, never bulk-loaded
+L1 (always in context)   CLAUDE.md + MEMORY.md + orientation cache (~60 lines)
+L2 (on-demand)           DIRECTORY.md, atlas, repomap, tracker, backlogs
+L3 (deep storage)        Codebase, git history — read by subagents, never bulk-loaded
 ```
 
-The **orientation cache** is an ephemeral daily file generated between sessions and injected at start via a `SessionStart` hook. It contains repo structure, health snapshot, recent work summary, and self-invalidating VCS metadata (`git_head_at_generation`). Every L1 entry points to an L2 artifact for drill-down.
+The **orientation cache** is the key. Generated by `/workday-start`, it's a ~60-line ephemeral summary that distills L2 artifacts into a compact briefing: top-ranked files, directory structure at a glance, health snapshot, doc freshness, and pointers to every L2 artifact for drill-down. It's injected at session start via a `SessionStart` hook. The next session doesn't load the full repo map or the full atlas — it loads a summary that *knows they exist* and can pull them on demand.
+
+**Fighting staleness.** The hard part of maintaining project documentation isn't generating it — it's keeping it current. `/update-docs` is an 11-phase maintenance pipeline that syncs all documentation artifacts against the codebase on every run: refreshing source indexes, archiving completed work, trimming lessons, checking the architecture atlas for unmapped files, and flagging drift. `/workday-start` surfaces staleness metrics at the top of each day — how many commits since the last doc sync, how many since the last bug sweep, which atlas systems are overdue for audit. The goal is that documentation is *trustworthy by default*, not aspirationally current.
+
+**"Grep bait" as a design principle.** Copious, status-tagged documentation across wikis, plans, archives, and trackers creates a secondary benefit: even a vague PM directive like "finish up that blueprint graph handling" produces hits across multiple artifacts — each with dates, status, and context — making it easy for Claude to gather orientation without a guided tour. The documentation isn't just for reading; it's searchable surface area that makes the codebase self-describing.
 
 ## Version History
 
-- **v1.1.1** — Staff sessions (Agent Teams for collaborative planning/review), README positioning rewrite
-- **v1.1.0** — Agent Teams adoption for all research pipelines; deep-research extracted to standalone plugin; context pressure advisory hooks
-- **v1.0.0** — Initial public release: 6 plugins, 24 agents, 38 skills, enrichment-review-execution pipeline
+- [**v1.1.1**](https://github.com/oduffy-delphi/coordinator-claude/releases/tag/v1.1.1) — Staff sessions (Agent Teams for collaborative planning/review), README positioning rewrite
+- [**v1.1.0**](https://github.com/oduffy-delphi/coordinator-claude/releases/tag/v1.1.0) — Agent Teams adoption for all research pipelines; deep-research extracted to standalone plugin; context pressure advisory hooks
+- [**v1.0.0**](https://github.com/oduffy-delphi/coordinator-claude/releases/tag/v1.0.0) — Initial public release: 6 plugins, 24 agents, 38 skills, enrichment-review-execution pipeline
 
 ---
 
-## Setup on a New Machine
+## Installation
 
 ### Prerequisites
-- Claude Code CLI installed
-- This repo cloned to `~/.claude/`
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed and authenticated
+- [jq](https://jqlang.github.io/jq/) — used by hook scripts for JSON parsing (`brew install jq` / `sudo apt install jq` / `winget install jqlang.jq`)
 
-### Step 1: Register the marketplace
+### Quick Start
 
 ```bash
-claude plugin marketplace add ~/.claude/plugins/oduffy-custom
+git clone https://github.com/oduffy-delphi/coordinator-claude.git
+cd coordinator-claude
+bash setup/install.sh
 ```
 
-This adds the marketplace to `known_marketplaces.json` and `settings.json` (`extraKnownMarketplaces`).
+The installer handles platform detection (macOS, Linux, Windows/Git Bash, WSL), interactive plugin selection, and all JSON registration. Use `--non-interactive` for unattended installs or `--plugins coordinator,game-dev` to specify an explicit list.
 
-### Step 2: Register plugins in installed_plugins.json
+Restart Claude Code after installation. See [docs/getting-started.md](docs/getting-started.md) for the full walkthrough.
 
-As of March 2026, `claude plugin install` does not fully support directory-based local marketplaces — it adds to `settings.json` but not `installed_plugins.json`. Add entries manually:
+<details>
+<summary>Manual Installation</summary>
+
+If you prefer to install manually or the script doesn't work for your setup:
+
+#### Step 1: Copy plugins
+
+```bash
+mkdir -p ~/.claude/plugins/coordinator-claude
+cp -r plugins/* ~/.claude/plugins/coordinator-claude/
+```
+
+#### Step 2: Register the marketplace
+
+Add to `~/.claude/plugins/known_marketplaces.json`:
+
+```json
+{
+  "coordinator-claude": {
+    "source": { "source": "directory", "path": "/home/{USERNAME}/.claude/plugins/coordinator-claude" },
+    "installLocation": "/home/{USERNAME}/.claude/plugins/coordinator-claude"
+  }
+}
+```
+
+#### Step 3: Register plugins in installed_plugins.json
+
+Add entries to `~/.claude/plugins/installed_plugins.json` — see [docs/getting-started.md](docs/getting-started.md) for the full JSON template with all plugin entries.
+
+#### Step 4: Enable plugins in settings.json
 
 ```jsonc
-// In ~/.claude/plugins/installed_plugins.json, add to "plugins" object:
-"coordinator@oduffy-custom": [{
-  "scope": "user",
-  "installPath": "C:\\Users\\<USERNAME>\\.claude\\plugins\\oduffy-custom\\coordinator",
-  "version": "1.0.0",
-  "installedAt": "<ISO-TIMESTAMP>",
-  "lastUpdated": "<ISO-TIMESTAMP>"
-}],
-"game-dev@oduffy-custom": [{
-  "scope": "user",
-  "installPath": "C:\\Users\\<USERNAME>\\.claude\\plugins\\oduffy-custom\\game-dev",
-  "version": "1.0.0",
-  "installedAt": "<ISO-TIMESTAMP>",
-  "lastUpdated": "<ISO-TIMESTAMP>"
-}],
-"web-dev@oduffy-custom": [{
-  "scope": "user",
-  "installPath": "C:\\Users\\<USERNAME>\\.claude\\plugins\\oduffy-custom\\web-dev",
-  "version": "1.0.0",
-  "installedAt": "<ISO-TIMESTAMP>",
-  "lastUpdated": "<ISO-TIMESTAMP>"
-}],
-"data-science@oduffy-custom": [{
-  "scope": "user",
-  "installPath": "C:\\Users\\<USERNAME>\\.claude\\plugins\\oduffy-custom\\data-science",
-  "version": "1.0.0",
-  "installedAt": "<ISO-TIMESTAMP>",
-  "lastUpdated": "<ISO-TIMESTAMP>"
-}]
+// In ~/.claude/settings.json, add to "enabledPlugins":
+"coordinator@coordinator-claude": true,
+"deep-research@coordinator-claude": true,
+"web-dev@coordinator-claude": true,       // or false
+"data-science@coordinator-claude": true,   // or false
+"game-dev@coordinator-claude": false,      // enable for Unreal Engine
+"notebooklm@coordinator-claude": false     // enable on demand
 ```
 
-### Step 3: Enable plugins in settings.json
+#### Step 5: Restart Claude Code
 
-Add to the `enabledPlugins` object in `~/.claude/settings.json`:
+Start a new session. Verify with `/reload-plugins`.
 
-```jsonc
-"coordinator@oduffy-custom": true,
-"game-dev@oduffy-custom": true,    // or false if not doing game dev
-"web-dev@oduffy-custom": true,     // or false if not doing web dev
-"data-science@oduffy-custom": true  // or false if not doing data science
+#### Plugin cache (development workflow)
+
+If editing plugin source files directly, use junctions/symlinks so the cache reflects your edits instantly:
+
+```bash
+# macOS/Linux
+ln -sf ~/.claude/plugins/coordinator-claude/{plugin} ~/.claude/plugins/cache/coordinator-claude/{plugin}/{version}
+
+# Windows (Git Bash or cmd)
+mklink /J plugins\cache\coordinator-claude\{plugin}\{version} plugins\coordinator-claude\{plugin}
 ```
 
-### Step 4: Create cache junctions (development workflow)
+</details>
 
-Claude Code reads from a cache directory, not directly from source. For a development workflow where you edit plugin source files directly, replace cache copies with junctions so edits are instantly visible:
+## First Session
 
-```cmd
-rem Run from ~/.claude/
-rem For each plugin, replace cache with junction to source:
-mklink /J plugins\cache\oduffy-custom\coordinator\1.0.0 plugins\oduffy-custom\coordinator
-mklink /J plugins\cache\oduffy-custom\game-dev\1.1.0 plugins\oduffy-custom\game-dev
-mklink /J plugins\cache\oduffy-custom\web-dev\1.0.0 plugins\oduffy-custom\web-dev
-mklink /J plugins\cache\oduffy-custom\data-science\1.0.0 plugins\oduffy-custom\data-science
-mklink /J plugins\cache\oduffy-custom\notebooklm\1.0.0 plugins\oduffy-custom\notebooklm
-```
+After installing, start a Claude Code session in any project directory:
 
-On macOS/Linux: `ln -sf ~/.claude/plugins/oduffy-custom/{plugin} ~/.claude/plugins/cache/oduffy-custom/{plugin}/{version}`
+1. Run `/session-start` — orients the session, loads context, surfaces pending work.
+2. For a brand new project, run `/project-onboarding` to bootstrap tracking infrastructure (project tracker, tasks directory, archive).
+3. Give Claude a task. The PM/EM dynamic activates naturally — Claude will plan, delegate, and review as the work requires.
 
-> **Note:** If installing from a git-based marketplace (not developing locally), the cache is managed by Claude Code automatically and this step is unnecessary.
-
-### Step 5: Restart Claude Code
-
-Start a new session and verify with `/reload-plugins`. You should see all custom plugin components in the count.
+See [docs/getting-started.md](docs/getting-started.md) for a full walkthrough of your first session.
 
 ## Directory Structure
 
@@ -171,14 +205,14 @@ coordinator-claude/
 ├── plugins/
 │   ├── coordinator/            # Core orchestration (always enabled)
 │   │   ├── .claude-plugin/plugin.json
-│   │   ├── agents/             # enricher, executor, patrik, zoli, review-integrator, staff-synthesizer
+│   │   ├── agents/             # enricher, executor, reviewers, review-integrator, staff-synthesizer
 │   │   ├── commands/           # handoff, session-start, session-end, staff-session, etc.
-│   │   ├── hooks/              # coordinator-reminder hook + capability catalog emission
+│   │   ├── hooks/              # context pressure advisory, executor watchdog, delegation nudge, capability catalog
 │   │   ├── pipelines/          # staff-session/ (team protocol + prompt templates)
 │   │   └── skills/             # 38 workflow skills (brainstorming, TDD, debugging, etc.)
-│   ├── game-dev/               # Sid (Unreal Engine specialist)
-│   ├── web-dev/                # Pali (front-end) + Fru (UX flow)
-│   ├── data-science/           # Camelia (ML, statistics)
+│   ├── game-dev/               # Unreal Engine specialist
+│   ├── web-dev/                # Front-end + UX flow reviewers
+│   ├── data-science/           # ML, statistics reviewer
 │   ├── deep-research/          # Agent Teams research pipelines (A: web, B: repo, C: structured)
 │   └── notebooklm/             # NotebookLM media research via Agent Teams
 ├── docs/                       # Architecture, customization, CI pipeline
@@ -186,49 +220,25 @@ coordinator-claude/
 └── assets/                     # Social preview card + generation template
 ```
 
-## Key Files (Not in This Directory)
-
-- `~/.claude/settings.json` — Plugin enable/disable state + marketplace registration
-- `~/.claude/plugins/installed_plugins.json` — Plugin install records
-- `~/.claude/plugins/known_marketplaces.json` — Marketplace registry
-- `~/.claude/CLAUDE.md` — Global development principles (the "constitution")
-
 ## Troubleshooting
 
 **Plugins not showing as skills/commands:**
-- Check `enabledPlugins` in `settings.json` — must be `true`
-- Check `installed_plugins.json` — must have entry with correct `installPath`
+- Check `enabledPlugins` in `~/.claude/settings.json` — must be `true`
+- Check `~/.claude/plugins/installed_plugins.json` — must have entry with correct `installPath`
+- Check `~/.claude/plugins/known_marketplaces.json` — must have marketplace entry
 - Restart Claude Code (changes take effect on next session)
+- The installer (`setup/install.sh`) manages all three files automatically
 
-**CLI `plugin install` fails silently:**
-- Known issue with directory-based local marketplaces (March 2026)
-- Use manual JSON entries as described in Step 2
+**Plugin cache not syncing after editing source:**
+- Claude Code caches plugins by version. Run `bash setup/dev-sync.sh` to sync, or see the Manual Installation section above for junction/symlink setup.
 
 **Per-project plugin selection:**
-- Use `.claude/coordinator.local.md` with `project_type` field
-- coordinator is always enabled; domain plugins enabled per-project
-
-**Plugin cache not syncing (solved with junctions):**
-- Claude Code reads plugins from `~/.claude/plugins/cache/oduffy-custom/{plugin}/{version}/`, not from source
-- **Fix:** Replace cache directories with Windows junctions pointing to source. This makes edits to source instantly visible in cache — no manual copying needed.
-- Setup (run from `~/.claude/`):
-  ```cmd
-  rem Remove the real cache directory, then create a junction to source
-  rmdir /s /q plugins\cache\oduffy-custom\{plugin}\{version}
-  mklink /J plugins\cache\oduffy-custom\{plugin}\{version} plugins\oduffy-custom\{plugin}
-  ```
-- On macOS/Linux, use symlinks instead: `ln -sf`
-- Junctions don't require admin privileges on Windows
-- All oduffy-custom plugins should have junctions set up — see Step 2 below
-
-**New plugin not found in marketplace:**
-- Plugin must be listed in `~/.claude/plugins/oduffy-custom/.claude-plugin/marketplace.json`
-- Without a marketplace entry, `installed_plugins.json` + `settings.json` entries will error: "Plugin not found in marketplace"
+- Create `.claude/coordinator.local.md` with `project_type` field
+- coordinator is always enabled; domain plugins activate per-project
 
 **Plugin-scoped MCP server not starting (Windows):**
 - Use `"command": "cmd", "args": ["/c", "your-command"]` in `.mcp.json` — bare command names may not resolve through the plugin loader's PATH
-- Verify the MCP server starts manually: `echo '{}' | your-command --help`
 
 ## Authors
 
-Dónal O'Duffy & Claude
+[Dónal O'Duffy](https://github.com/oduffy-delphi) & Claude


### PR DESCRIPTION
## Summary

Major README revision across three rounds of edits:

- **Feature reranking by impact**: Agent Teams research/planning leads (headline-grabbing, genuinely different usage of the beta), followed by layered project knowledge, prospective handoffs, inverted capability delegation, condensed persona review
- **New sections**: Customization (persona renaming, custom reviewers, per-project config), First Session guidance, Project Knowledge (layered context vs Aider repo-map pattern, staleness-fighting, grep bait)
- **Installer-first setup**: 3-line quick start replaces 80 lines of manual JSON; manual steps collapsed into `<details>`
- **Depersonalized**: org table addresses the reader ("You") not the author; PM/EM doctrine reframed for adopters
- **Housekeeping**: version history tagged, Key Files folded into Troubleshooting, hooks comment updated

## Test plan

- [ ] All internal doc links resolve (getting-started.md, customization.md, architecture.md, research docs)
- [ ] GitHub anchor link to Project Knowledge section works
- [ ] No stale personal references leaked

🤖 Generated with [Claude Code](https://claude.com/claude-code)