### PR TITLE
Work: striker 2026-05-01 obsidian borrows sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to coordinator-claude are documented here.
 
+## [1.6.0] — 2026-05-01
+
+### Theme — Orphan-Branch Prevention
+
+In response to a 2026-05-01 postmortem (15 commits stranded for 22 hours on a branch whose source-PR had already merged, with downstream sessions actively rewriting docs to claim "shipped"), the coordinator pipeline gains structural defenses against orphan branches and false "shipped" claims. Three shared helpers, six surfaces hardened, one paragraph of doctrine.
+
+### Added
+- **`bin/orphan-branch-sweep.sh`** — enumerates `work/*` and `feature/*` branches owned by the user, classifies CRITICAL (commits added after a PR merged from this branch) / WARNING (no PR, ahead, ≥2 days old or >36h) / OK. JSON or text output, `--severity-min` filtering eliminates `| jq` / `| grep` parsing at every call site.
+- **`bin/sync-main.sh`** — fetch + ff-only invariant called before any branch creation. Uses `git fetch origin main:main` refspec form so local `main == origin/main` regardless of which branch the working tree is on. Every `git checkout -b` site in the coordinator pipeline now runs this first.
+- **`bin/check-shipped-on-main.sh`** — thin wrapper around `git merge-base --is-ancestor` so "shipped" claims have a single authoritative answer.
+- **`commands/workday-start.md` Step 0.5** — new orphan sweep surfaces CRITICAL/WARNING branches in the Morning Briefing before any new work begins.
+- **`commands/workday-start.md` Step 0 Branch Reconciliation Decision** — when yesterday's branch can't be merged forward, the PM is forced to choose A (consolidate now) / B (defer with re-check date in `tasks/.deferred-branches.md`) / C (archive). TTY-aware: blocks interactively, auto-defers in non-interactive (overnight) sessions.
+- **Tracking file `tasks/.deferred-branches.md`** — single-line entries managed by the Branch Reconciliation Decision flow; surfaced when re-check date arrives.
+
+### Changed
+- **`commands/handoff.md` Step 3** — pre-flight reachability check on completed-work commits. When commits aren't on `origin/main`, "shipped" wording is replaced with "complete on branch, not yet merged" and a `## Not Yet On Main` section is appended.
+- **`commands/update-docs.md`, `commands/distill.md`, `commands/architecture-audit.md`** — explicit DO-NOT-MERGE prohibition inline in Sonnet dispatch prompts. Closes the 2026-05-01 rogue-merge trigger (a doc-maintenance Sonnet ran `gh pr merge` autonomously).
+- **`skills/merging-to-main/SKILL.md`** — Step 4 5-min quiet gate (cross-platform `gh`+Python snippet, override via `--force-merge-active-branch`); Step 6 reports other unmerged branches owned by the user.
+- **`skills/using-git-worktrees/SKILL.md`, `commands/workday-complete.md`, `commands/session-start.md`** — `sync-main.sh` injected at every branch-creation site.
+- **`coordinator/CLAUDE.md`** — one paragraph added to "Verification Before Done" ("Shipped means on `origin/main`, not on a branch tip"), one bullet under "Git Commit Policy" pointing at `sync-main.sh` + the workday-start contract, and a tripwire entry naming the three skills that must carry the gh-merge prohibition. Aggressive compression — ~5 lines total addition, lean per-PM-direction.
+
+### Internal
+- **Test fixture** `tests/plugins/orphan-sweep.test.js` covering the three severity classes with stubbed `gh`.
+
+### Why this matters
+The git tree is the only authoritative answer to "is this shipped." Handoffs, docs, and orientation cache are downstream artifacts that inherit any lie planted upstream — in the postmortem, a single false "shipped" claim propagated through five layers of artifacts in 24 hours, and a follow-on session struck a real shipped tool from the docs as "never built." This release closes the surfaces where that lie can be authored.
+
 ## [1.5.0] — 2026-04-30
 
 ### Theme — Build For Someone Else's Machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to coordinator-claude are documented here.
 
+## [1.7.0] — 2026-05-01
+
+### Theme — Portable Ideas from Obsidian (W1+W2+W3)
+
+Three workstreams percolated from `~/.claude` HEAD as a single bundle (R2 APPROVED_WITH_NOTES, all 7 findings integrated). Schemas + lint belt, live-query primitives, and tiered context-loading doctrine — each tackling a different decay mode in the coordinator pipeline.
+
+### Added
+- **W1 — Frontmatter schemas + lint belt + PreToolUse validator.** New `schemas/{handoff,plan,review,decision,worker-run,lesson-entry}.yaml`, shared `bin/lib/schema.{js,test.js}` validator (with code-span / link-text robustness), `bin/lint-frontmatter.{sh,js}` CLI, and `hooks/scripts/validate-frontmatter-schema.{js,test.js}` PreToolUse hook (default WARN mode; `COORDINATOR_SCHEMA_STRICT=1` to deny).
+- **W2 — Live queries CLI + sentinel-block primitives.** `bin/query-records.{js,sh}` queries frontmatter-indexed records; `bin/refresh-queries.{js,sh}` regenerates `<!-- BEGIN query: ... -->` callouts in markdown (consumed by `/update-docs` Phase 11c); `bin/lib/sentinel-blocks.{js,test.js,cli.js}` factor out shared sentinel-block extraction (now delegated by `verify-preamble-sync.sh` and `verify-calibration-sync.sh`).
+- **W3 — Tiered context loading doctrine + telemetry.** New `docs/wiki/tiered-context-loading.md` canonical guide; `coordinator/CLAUDE.md` "Codebase Investigation" section rewritten to enumerate tiers 0–4 plus the tier-4 rationale rule; `hooks/scripts/track-tier-usage.sh` PostToolUse telemetry counter classifies each tool call by tier and detects the rationale preamble; `/session-end` Step 0 emits a tier-usage report.
+
+### Changed
+- **Doctrine + preamble syncs** across `CLAUDE.md`, `agents/staff-eng`, and commands `{distill, handoff, mise-en-place, session-start, session-end, update-docs}` to thread the new tiered-context model and rationale rule through the agent surfaces that consume them.
+
+### Internal
+- Test coverage for `schema.js` (code-span / link-text edge cases), `query-records`, and `sentinel-blocks` modules.
+
 ## [1.6.0] — 2026-05-01
 
 ### Theme — Orphan-Branch Prevention

--- a/docs/wiki/tiered-context-loading.md
+++ b/docs/wiki/tiered-context-loading.md
@@ -1,0 +1,161 @@
+# Tiered Context Loading
+
+> Spec backlink: `docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md` §W3
+
+The EM's context window is the scarcest resource in any session. Every token consumed by exploratory lookup is a token unavailable for reasoning, reviewing, or holding the plan. Tiered context loading is the discipline that prevents that burn — not by refusing to look things up, but by requiring the cheapest adequate lookup to run before the expensive one.
+
+---
+
+## 1. Why Tiers Exist
+
+The existing "Codebase Investigation" section in `coordinator/CLAUDE.md` described an investigation funnel informally — orientation cache, then wiki/atlas, then project-RAG, then grep, then scout — but never named the tiers or made the escalation order a hard requirement. The cost of skipping to a Sonnet scout when a Grep call would have answered the question is real: the scout takes up an Agent dispatch, pulls minutes of wall time, consumes a subagent context, and usually returns more context than needed — inflating the EM's window with noise.
+
+**The goal of this doctrine is not to name what we do. It is to make the escalation order visible and measurable so that violations are detectable.**
+
+Two behavioral levers operationalize this:
+
+1. **Tier-4 rationale rule** — every Agent dispatch for investigation must include a one-line preamble stating what tiers 1–3 returned and why they were insufficient.
+2. **Session-end telemetry** — a PostToolUse hook counts tool calls by tier; `/session-end` emits a per-session report. Trends across sessions reveal whether the doctrine is followed or drifting.
+
+---
+
+## 2. The Five Tiers
+
+| Tier | Name | Budget | Surfaces |
+|------|------|--------|----------|
+| 0 | Boot context | ≤2K tokens, always loaded | `orientation_cache.md`, `lessons.md`, `CLAUDE.md` (auto-loaded), session memory pointers |
+| 1 | Curated narrative | ≤8K tokens per fetch, on demand | `docs/wiki/`, `tasks/architecture-atlas/`, `docs/decisions/`, `docs/project-tracker.md` |
+| 2 | Structured query | ≤2K tokens per query | `bin/query-records`, `mcp__*project-rag*__*`, `/workday-start` freshness table |
+| 3 | Targeted code/grep | ≤4K tokens per call | `Read` of a known path, `Grep` for a specific symbol, `Glob` for discovery |
+| 4 | Sonnet scout | Offloaded to subagent | `Explore`, `general-purpose` Sonnet, `deep-research:repo`, `feature-dev:code-explorer` |
+
+**Tier 0 — Boot context** is always present before the first tool call. It costs nothing at investigation time because it was loaded at session start: `orientation_cache.md` gives the project's current state, `lessons.md` records accumulated gotchas, and session memory pointers anchor any cross-session continuity. Boot context is not a lookup tier; it is the baseline from which escalation begins.
+
+**Tier 1 — Curated narrative** contains human-authored and distilled documents that describe how subsystems work at a level above code: wiki guides, architecture atlas pages, decision records. These are the product of previous investigation cycles — they exist precisely so future sessions don't have to re-derive the same structural knowledge from grep. A tier-1 read of `tasks/architecture-atlas/systems/auth.md` is almost always more informative than ten tier-3 Greps across the same system.
+
+**Tier 2 — Structured query** returns precise, bounded answers from indexed data. Project-RAG tools answer symbol-shaped and subsystem-shaped questions in a single call with ≤2K tokens. `bin/query-records` answers schema-conformant queries against frontmatter records. Tier 2 is fast and narrow; its failure mode is returning nothing rather than returning wrong information.
+
+**Tier 3 — Targeted code/grep** is direct inspection: reading a specific file, grepping for a symbol by name, globbing for a pattern. It is powerful and accurate but expensive in proportion to the answer size — a Grep on a large codebase can return hundreds of lines of context. Tier 3 is appropriate when you know where to look; it is not appropriate as a substitute for tier 1 or tier 2 when curated knowledge covers the question.
+
+**Tier 4 — Sonnet scout** offloads open-ended investigation to a subagent. This is the correct choice when tiers 0–3 genuinely returned nothing useful and the question requires reasoning across multiple files or dynamic discovery. Tier-4 dispatches are the most expensive lookup in the funnel: they consume subagent context, take wall time, and return unstructured output that the EM must parse. They are not a default; they are a last resort.
+
+---
+
+## 3. Escalation Rules
+
+**Start at tier 0. Escalate one tier at a time. Never skip.**
+
+The most common violation is skip-to-scout: dispatching a tier-4 Explore or general-purpose agent when tier 2 or tier 3 would have answered the question. The second most common is premature-grep: jumping to tier 3 before checking whether tier 1 or tier 2 covers the topic.
+
+### Worked Example A — "Where is X defined?"
+
+This is a symbol-shaped question. Correct escalation:
+
+1. **Tier 0 check:** Is the symbol mentioned in `orientation_cache.md` or `lessons.md`? If the answer is there, done.
+2. **Tier 2:** Call `project_cpp_symbol` or `project_semantic_search` if project-RAG tools are available. A clean hit returns file + line in one call. Done.
+3. **Tier 3:** If RAG is unavailable or returns nothing, `Grep` for the symbol name across relevant directories. Read the matching file for context. Done.
+4. **Tier 4 only if:** tier 3 returned nothing (symbol doesn't exist, is generated, or lives in a location grep didn't cover) AND the question can't be answered without cross-file reasoning. Dispatch preamble required (see §7).
+
+This question should almost never reach tier 4.
+
+### Worked Example B — "How does subsystem X work?"
+
+This is a subsystem-shaped question. Correct escalation:
+
+1. **Tier 0 check:** Is there an orientation note or lesson about this subsystem?
+2. **Tier 1:** Read the relevant architecture atlas page (`tasks/architecture-atlas/systems/<subsystem>.md`) or the corresponding wiki guide (`docs/wiki/<subsystem>.md`) if it exists. A good tier-1 read answers subsystem questions comprehensively without any code inspection. Done in most cases.
+3. **Tier 2:** If the wiki/atlas doesn't cover the question, call `project_subsystem_profile` to get a structural summary. Done.
+4. **Tier 4:** If tiers 1–3 return nothing (the subsystem is new, undocumented, or the atlas is known stale), dispatch a scout with the rationale preamble. The scout's job is to produce a tier-1 artifact (e.g., a new atlas page) so this question doesn't hit tier 4 again next session.
+
+---
+
+## 4. Skipping Rules
+
+Not every lookup requires climbing from tier 0. Skipping is correct in these cases:
+
+- **Known path, direct read:** If you already know the exact file path from context, go straight to `Read` (tier 3). Consulting tier 1 or tier 2 first would be redundant overhead.
+- **Single-fact confirmation:** If you need to confirm one specific fact — a function signature, a config value — and you know roughly where it lives, tier 3 directly is correct.
+- **Repeat lookup with cached answer:** If you answered this question earlier in the session and the answer is still in context, use the cached answer. Do not re-run any tier.
+- **Tier 1 explicitly covers the topic:** If `orientation_cache.md` (tier 0) says "see `tasks/architecture-atlas/systems/auth.md`," jump to that file (tier 1) directly — no tier 2 needed.
+
+The guiding test: **could a cheaper tier have answered this question?** If yes and you skipped it, that is a violation regardless of whether the answer you got was correct.
+
+---
+
+## 5. Tier–Tool Mapping
+
+| Tier | Claude Code Tools |
+|------|-------------------|
+| 0 | Auto-loaded at session start — no tool call needed |
+| 1 | `Read` of wiki, atlas, decisions, or tracker paths |
+| 2 | `mcp__*project-rag*__*` tools; `Bash` invoking `bin/query-records` or `bin/lint-frontmatter` |
+| 3 | `Read` of any other path; `Grep`; `Glob` |
+| 4 | `Agent` with `subagent_type` in {`Explore`, `general-purpose`, `deep-research:*`, `feature-dev:code-explorer`} |
+
+Note: `Bash` calls that are not `bin/query-records` or RAG-adjacent fall outside the tier classification and are not tracked. Telemetry ignores them.
+
+---
+
+## 6. Failure Modes
+
+**Skip-to-scout (most common).** Dispatching a tier-4 agent when tier 2 or tier 3 would have answered the question. Symptoms: scout returns a brief that could have come from a single Grep; tier-usage report shows tier4 >> tier2+tier3; dispatch prompt contains no rationale preamble. Fix: run the tier-4 rationale rule check before every Agent dispatch.
+
+**Redundant tier.** Re-running a tier after it already returned a clean answer. The most common variant is re-grepping after a tier-2 RAG call returned the symbol location. Wastes tokens without adding information.
+
+**Premature grep.** Jumping to tier 3 before checking whether tier 1 or tier 2 covers the topic. Symptoms: Grep is the first non-tier-0 tool call in the session; wiki/atlas are never consulted; questions like "how does X work" are answered by grep aggregation rather than structured knowledge. Fix: make tier-1 reads the default first step for any subsystem question.
+
+**Stale tier-1 bypass.** Skipping tier 1 because the wiki/atlas is "probably stale." Stale RAG and stale atlas still cover the structural skeleton; grep covers none of it. Use the stale artifact first, then fill gaps with tier 3. Staleness is a signal to update the artifact after the session, not a reason to skip it during.
+
+---
+
+## 7. Tier-4 Rationale Rule
+
+Every `Agent` dispatch where `subagent_type` is in `{Explore, general-purpose, deep-research:*, feature-dev:code-explorer}` **must** include the following preamble as the first line of the dispatch prompt:
+
+```
+Tier 1-3 attempted: <what each returned>; insufficient because <reason>.
+```
+
+Examples:
+
+```
+Tier 1-3 attempted: atlas has no page for the payments subsystem, RAG returned no matches for PaymentProcessor, grep found 0 results in src/payments/; insufficient because the module may live under a non-obvious path.
+```
+
+```
+Tier 1-3 attempted: wiki guide covers auth at a high level, RAG symbol search returned AuthManager:line 42, Read confirmed it's a thin wrapper; insufficient because the actual auth logic is in the middleware chain and the atlas doesn't map it.
+```
+
+The rationale preamble does three things: it forces the EM to verify that tiers 1–3 were actually tried (not assumed to return nothing), it gives the scout useful negative context (what was already checked), and it produces a visible artifact that Patrik and the review-integrator can flag if the rationale is implausible.
+
+Dispatches missing the preamble are flagged as `rationale_present: false` by the telemetry hook (see §8).
+
+---
+
+## 8. Telemetry
+
+`~/.claude/plugins/coordinator-claude/coordinator/hooks/scripts/track-tier-usage.sh` runs as a PostToolUse hook on every tool call matching `Read|Grep|Glob|Bash|Agent|mcp__.*`. It classifies each call into a tier and increments per-session counters persisted to:
+
+```
+~/.claude/projects/<project-slug>/tier-usage/<session_id>.json
+```
+
+JSON shape:
+```json
+{
+  "session_id": "...",
+  "started_at": "ISO-date",
+  "counts": { "tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0 },
+  "tier4_dispatches": [
+    { "ts": "...", "subagent_type": "...", "rationale_present": true }
+  ]
+}
+```
+
+At `/session-end` and `/workday-complete`, the session's tier-usage JSON is read and a one-line report is emitted before the wrap-up:
+
+```
+Tier usage this session: tier1=N tier2=N tier3=N tier4=N (X tier-4 missing rationale)
+```
+
+This report is the data that prevents W3 from being ceremonial. If after several sessions the counters show tier4 >> tier2+tier3 or consistent missing-rationale counts, the doctrine is not being followed — revise the enforcement, not the doctrine.

--- a/plugins/coordinator/.claude-plugin/plugin.json
+++ b/plugins/coordinator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coordinator",
-  "version": "1.0.0",
+  "version": "1.6.0",
   "description": "Turn Claude Code into a structured development partner — session lifecycle, named code reviewers, research pipelines, and 23 workflow skills that enforce quality from plan through execution.",
   "author": {
     "name": "Dónal O'Duffy & Claude"

--- a/plugins/coordinator/CLAUDE.md
+++ b/plugins/coordinator/CLAUDE.md
@@ -43,6 +43,8 @@ Process alone fails — conventions decay unless greppable from the surfaces age
 
 - **Tripwire — reviewer calibration:** The live reviewer prompt files carry the calibration scale verbatim between sentinel comments (`<!-- BEGIN reviewer-calibration (synced from snippets/reviewer-calibration.md) -->` … `<!-- END reviewer-calibration -->`). The consumers are: `plugins/coordinator-claude/coordinator/agents/staff-eng.md`, `plugins/claude-unreal-holodeck/coordinator/agents/staff-eng.md` (if it exists), `plugins/coordinator-claude/game-dev/agents/staff-game-dev.md`, `plugins/claude-unreal-holodeck/game-dev/agents/staff-game-dev.md`, `plugins/coordinator-claude/web-dev/agents/senior-front-end.md`, `plugins/coordinator-claude/data-science/agents/staff-data-sci.md`. When editing the calibration scale: (1) edit `snippets/reviewer-calibration.md` — that is the single authoring source; (2) run `bin/verify-calibration-sync.sh --fix` to propagate the change to all consumers; (3) commit all touched files together in one commit. Never edit consumer sentinel blocks directly — they will be overwritten on the next sync.
 
+- **Tripwire — gh-merge prohibition in doc-maintenance dispatch prompts:** Three skills dispatch Sonnet agents that touch git and must carry an explicit "DO NOT run `gh pr merge`, `gh pr create` against main, or `git push origin main`" prohibition inline in their dispatch prompt: `/update-docs` (Execution model paragraph, Phases 1–11b dispatch), `/distill` (any Phase that commits or pushes), `/architecture-audit` (Phase 4 integration commit). When adding a NEW skill that dispatches a Sonnet agent with write access to git, add it to this list. Purpose: prevent doc-maintenance agents from autonomously merging PRs to main (postmortem: 2026-05-01 incident where `/update-docs` Phase 9 agent created and merged PR #6 directly).
+
 ## Agent Teams — `blockedBy` Is a Gate, Not a Trigger
 
 A teammate that checks `blockedBy` and goes idle will NOT auto-resume when the blocker clears. The unblocker must `SendMessage` to wake it. Always pair `blockedBy` with a wake-up in the unblocker's done-protocol.
@@ -129,6 +131,8 @@ The predecessor is **whatever handoff this session was opened with — period.**
 
 Never mark a task complete without proving it works — run tests, check logs, demonstrate correctness. When dispatching agents, verify their output before proceeding (empty results, truncation, format).
 
+**"Shipped" means on `origin/main`, not on a branch tip.** Before any handoff, doc, lessons entry, or memory update asserts work has shipped/landed, run `bin/check-shipped-on-main.sh <commit>` for at least one canonical commit per claim. Branch-tip is not shipping; PR-merged-from-this-branch is shipping IF AND ONLY IF no further commits were added to the source branch after the merge. The git tree is the only authoritative answer.
+
 ## Build For Someone Else's Machine
 
 Default assumption: the code will run on a machine you've never seen — different OS, different drive layout, different project names. Portability is the baseline, not a feature. For any path the code consults: explicit flag → env var → marker auto-discovery (sentinel file, tool-owned data dir) → silent skip (opt-in tools) or hard error with remediation (explicitly invoked tools). A hardcoded local path is acceptable only as a last-resort fallback after the above, and only when its absence wouldn't silently misbehave. Project-scoped tools need a cwd-scope guard so they don't emit output outside their indexed root. Test fixtures and battle-story comments are exempt — the rule targets runtime values consulted on real invocations.
@@ -185,6 +189,7 @@ P0/P1 severity claims from sweep agents have a poor track record. Before acting 
 - **Scoped staging is the default. Never `git add -A` or `git add .` for routine commits.** Use `~/.claude/plugins/coordinator-claude/coordinator/bin/coordinator-safe-commit "<subject>"`. Two ceremonies are exempt and use `--blanket`: `/session-start` and `/workday-complete` (set `CLAUDE_INVOKING_COMMAND` accordingly). Emergency bypass: `COORDINATOR_OVERRIDE_SCOPE=1`.
 - **Helper misidentified your session?** Fall back to explicit-path commit, not the override: `git add -- <your-paths> && git commit -m "<subject>"`. Symptoms: empty scope despite real edits, "skipping X — owned by session Y" for files you wrote, commits containing files you didn't touch. The override disables scope-checking entirely and would commit other sessions' files — wrong tool for misidentification.
 - **Full guide:** `~/.claude/docs/wiki/scoped-safety-commits.md` (rationale, troubleshooting, deny-mode flip).
+- **Branch hygiene.** Never branch from stale main; lingering branches resolve at `/workday-start` (consolidate, defer, or archive). See `bin/sync-main.sh` and the workday-start Step 0 contract.
 
 ## Core Principles
 

--- a/plugins/coordinator/CLAUDE.md
+++ b/plugins/coordinator/CLAUDE.md
@@ -11,15 +11,31 @@ Two tiers:
 
 ## Codebase Investigation
 
-Lookup order when you need to understand the codebase:
+Context is the EM's scarcest resource. Investigation lookups are tiered: start at the cheapest tier that could answer the question, escalate one step at a time, never skip. Full doctrine: `docs/wiki/tiered-context-loading.md`.
 
-1. **Accumulated knowledge first.** Architecture atlas (`tasks/architecture-atlas/`), wiki (`docs/wiki/DIRECTORY_GUIDE.md`), repomap (`tasks/repomap.md`), docs index (`docs/README.md`). Skip silently if absent.
-2. **Project-RAG step 1.5.** If any `mcp__*project-rag*` tools are available in this session, prefer them over grep/Explore for any code-shaped lookup before dispatching a scout. Symbol-shaped questions ("where is X defined", "which class handles Y") → `project_cpp_symbol` / `project_semantic_search`. Subsystem-shaped questions ("how does subsystem X work") → `project_subsystem_profile`. Impact questions ("what breaks if I change X") → `project_referencers` with depth=2. Stale RAG still beats grep on structure. Fall through to grep/Explore only if RAG returns nothing AND staleness is plausible.
-3. **Dispatch a Sonnet scout, don't search yourself.** Use `Explore` for read-only briefs; `general-purpose` when the deliverable must land on disk. Brief like a teammate. The EM's context is the scarcest resource — protect it.
+**Tier 0 — Boot context (always present).** `orientation_cache.md`, `lessons.md`, session memory. Loaded at start; no tool call needed. Check these before any lookup.
 
-**Exceptions (EM may search directly):** reading a single known file before editing; 1-2 call confirmation of a known symbol; dispatch overhead clearly exceeds the lookup.
+**Tier 1 — Curated narrative (on demand).** Architecture atlas (`tasks/architecture-atlas/`), wiki guides (`docs/wiki/`), decision records (`docs/decisions/`), docs index (`docs/README.md`). ≤8K tokens per fetch. For subsystem-shaped questions ("how does X work", "what decisions were made about Y"), this tier answers most questions without any code inspection.
+
+**Tier 2 — Structured query (on demand).** If any `mcp__*project-rag*` tools are available, prefer them over grep or scout for any code-shaped lookup. Symbol-shaped questions → `project_cpp_symbol` / `project_semantic_search`. Subsystem-shaped → `project_subsystem_profile`. Impact → `project_referencers` with depth=2. `bin/query-records` for frontmatter-indexed records. Stale RAG still beats grep on structure. ≤2K tokens per query.
+
+**Tier 3 — Targeted code/grep (on demand).** `Read` of a known path, `Grep` for a specific symbol, `Glob` for pattern discovery. Use when tier 1–2 leave a specific gap — exact line numbers, recent additions not yet in the atlas, a symbol not in the RAG index. ≤4K tokens per call.
+
+**Tier 4 — Sonnet scout (last resort).** Dispatch `Explore` (read-only briefs) or `general-purpose` (deliverable lands on disk) only when tiers 1–3 have returned nothing useful for the question. The EM's context is the scarcest resource — offloading to a scout is not free.
+
+**Tier-4 rationale rule (hard requirement).** Every `Agent` dispatch with `subagent_type` in `{Explore, general-purpose, deep-research:*, feature-dev:code-explorer}` MUST begin with:
+```
+Tier 1-3 attempted: <what each returned>; insufficient because <reason>.
+```
+Dispatches missing this preamble are flagged by the telemetry hook as `rationale_present: false` and are reviewable by Patrik.
+
+**Exceptions (EM may go direct without full escalation):** reading a single known file before editing; 1–2 call confirmation of a known symbol; dispatch overhead clearly exceeds the lookup. Tier-4 rationale rule still applies when dispatching scouts.
 
 Delegated agents (enrichers, reviewers, executors) have narrower scope and may search directly within their brief.
+
+## Live Queries vs. Scaffolded Indices
+
+When the answer is derivable from frontmatter on tracked records, prefer `bin/query-records` over hand-maintained tables. Static scaffolding is for narrative content; queries are for structured records. `/update-docs` regenerates query callouts via `bin/refresh-queries.js`. Add a query callout (with sentinel comments) rather than a static list whenever the data is schema'd.
 
 ## Internet Research
 
@@ -44,6 +60,8 @@ Process alone fails — conventions decay unless greppable from the surfaces age
 - **Tripwire — reviewer calibration:** The live reviewer prompt files carry the calibration scale verbatim between sentinel comments (`<!-- BEGIN reviewer-calibration (synced from snippets/reviewer-calibration.md) -->` … `<!-- END reviewer-calibration -->`). The consumers are: `plugins/coordinator-claude/coordinator/agents/staff-eng.md`, `plugins/claude-unreal-holodeck/coordinator/agents/staff-eng.md` (if it exists), `plugins/coordinator-claude/game-dev/agents/staff-game-dev.md`, `plugins/claude-unreal-holodeck/game-dev/agents/staff-game-dev.md`, `plugins/coordinator-claude/web-dev/agents/senior-front-end.md`, `plugins/coordinator-claude/data-science/agents/staff-data-sci.md`. When editing the calibration scale: (1) edit `snippets/reviewer-calibration.md` — that is the single authoring source; (2) run `bin/verify-calibration-sync.sh --fix` to propagate the change to all consumers; (3) commit all touched files together in one commit. Never edit consumer sentinel blocks directly — they will be overwritten on the next sync.
 
 - **Tripwire — gh-merge prohibition in doc-maintenance dispatch prompts:** Three skills dispatch Sonnet agents that touch git and must carry an explicit "DO NOT run `gh pr merge`, `gh pr create` against main, or `git push origin main`" prohibition inline in their dispatch prompt: `/update-docs` (Execution model paragraph, Phases 1–11b dispatch), `/distill` (any Phase that commits or pushes), `/architecture-audit` (Phase 4 integration commit). When adding a NEW skill that dispatches a Sonnet agent with write access to git, add it to this list. Purpose: prevent doc-maintenance agents from autonomously merging PRs to main (postmortem: 2026-05-01 incident where `/update-docs` Phase 9 agent created and merged PR #6 directly).
+
+- **Tripwire — query callouts:** Live `<!-- BEGIN query: ... -->` callouts in markdown files are regenerated by `bin/refresh-queries.js`. Edit the callout spec line, never the expanded block — the expansion will be overwritten on next refresh. `refresh-queries.sh` runs as part of `/update-docs` Phase 11c; `--check` is the verification mode for ad-hoc validation (e.g., pre-merge). When introducing a new query callout, run `bin/refresh-queries.sh` locally before committing.
 
 ## Agent Teams — `blockedBy` Is a Gate, Not a Trigger
 
@@ -187,7 +205,7 @@ P0/P1 severity claims from sweep agents have a poor track record. Before acting 
 - **Commits are quick-saves.** Commit at natural checkpoints; don't wait to be asked.
 - **Use `/merge-to-main`** or `/workday-complete` to integrate. Never push directly.
 - **Scoped staging is the default. Never `git add -A` or `git add .` for routine commits.** Use `~/.claude/plugins/coordinator-claude/coordinator/bin/coordinator-safe-commit "<subject>"`. Two ceremonies are exempt and use `--blanket`: `/session-start` and `/workday-complete` (set `CLAUDE_INVOKING_COMMAND` accordingly). Emergency bypass: `COORDINATOR_OVERRIDE_SCOPE=1`.
-- **Helper misidentified your session?** Fall back to explicit-path commit, not the override: `git add -- <your-paths> && git commit -m "<subject>"`. Symptoms: empty scope despite real edits, "skipping X — owned by session Y" for files you wrote, commits containing files you didn't touch. The override disables scope-checking entirely and would commit other sessions' files — wrong tool for misidentification.
+- **Helper misidentified your session?** Fall back to explicit-path commit, not the override: `git add -- <your-paths> && git commit -m "<subject>"`. Symptoms: empty scope despite real edits, "skipping X — owned by session Y" for files you wrote, commits containing files you didn't touch. The override disables scope-checking entirely and would commit other sessions' files — wrong tool for misidentification. Setting `CLAUDE_SESSION_ID` inline (`CLAUDE_SESSION_ID=… safe-commit`) works for single-call use but does not change cross-session resolution behavior — the variable is per-invocation, not session-sticky.
 - **Full guide:** `~/.claude/docs/wiki/scoped-safety-commits.md` (rationale, troubleshooting, deny-mode flip).
 - **Branch hygiene.** Never branch from stale main; lingering branches resolve at `/workday-start` (consolidate, defer, or archive). See `bin/sync-main.sh` and the workday-start Step 0 contract.
 

--- a/plugins/coordinator/agents/staff-eng.md
+++ b/plugins/coordinator/agents/staff-eng.md
@@ -65,6 +65,16 @@ Before beginning your review, check for these project-level documents and read t
 - Coupling must be loose, cohesion must be high
 - SOLID principles are not suggestions—they are requirements
 
+### Agent-First Doctrine (post-2026-04-30)
+
+Apply the design rubric in `docs/plans/2026-04-30-agent-first-platform.md` §2 to any diff that:
+
+- **adds** a new MCP verb, batch CLI job, headless handler, or shell-cascade branch — challenge the addition against Q1 (C++-only capability?), Q2 (composes ≥3 primitives or encodes sequencing?), Q3 (operator-judgment branching?), Q4 (transactional state coupling?). If the answer is "agents could compose this," the addition needs explicit C++-capability or transactional-sequencing justification, not "nicer API."
+- **deletes** prior orchestration in favor of agent dispatch — challenge **harder**. The prior path is the default execution lane, the result of multiple rounds of staff review against a real project. Removal needs explicit retire-justification per §6 of the plan, with PM sign-off, not silent replacement.
+- **silently swaps a recipe for primitive composition** in implementation code — flag as a digression-governance violation. Digression requires an EM-approved (a)(b)(c)(d) request per §1 of the plan; in-PR composition without that request is a doctrine violation regardless of whether the composed result is correct.
+
+The doctrine is additive: existing convenience verbs, batch jobs, and shell cascades stay as the proven path. New work biases toward agent dispatch with explicit justification when adding native surface.
+
 ### Testing
 - Critical paths must have test coverage
 - Edge cases must be tested

--- a/plugins/coordinator/bin/check-shipped-on-main.sh
+++ b/plugins/coordinator/bin/check-shipped-on-main.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-shipped-on-main.sh — verify that one or more commits are reachable from
+#                             origin/main (i.e., actually shipped).
+#
+# Spec backlink: docs/plans/2026-05-01-orphan-branch-prevention.md § 1.2
+#
+# Purpose: thin wrapper around `git merge-base --is-ancestor` providing a
+# consistent "is this work on main?" query. Its existence is the doctrine
+# signal — callers (handoff.md, lessons, etc.) name this script rather than
+# inventing their own one-liner, so the definition of "shipped" stays in one
+# place and is greppable.
+#
+# Negative-spec: read-only. Never modifies the repo.
+
+set -euo pipefail
+
+VERBOSE=0
+COMMITS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose|-v) VERBOSE=1; shift ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: check-shipped-on-main.sh [--verbose] <commit> [<commit>...]
+
+Checks whether all given commits are ancestors of origin/main.
+
+Arguments:
+  commit       A commit SHA, branch tip, or symbolic ref (e.g. HEAD).
+               Accepts one or more.
+
+Options:
+  --verbose    Print one line per commit: "{sha}: ON_MAIN" or "{sha}: NOT_ON_MAIN ({age})"
+  --help       Show this help
+
+Exit codes:
+  0  All commits are on origin/main.
+  1  At least one commit is NOT on origin/main.
+  2  Not inside a git repository, or origin/main is unreachable.
+EOF
+      exit 0
+      ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *)  COMMITS+=("$1"); shift ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+  echo "check-shipped-on-main: not inside a git repository" >&2
+  exit 2
+fi
+
+if ! git rev-parse origin/main &>/dev/null 2>&1; then
+  # Try fetching
+  git fetch origin main --quiet 2>/dev/null || true
+  if ! git rev-parse origin/main &>/dev/null 2>&1; then
+    echo "check-shipped-on-main: origin/main is not reachable" >&2
+    exit 2
+  fi
+fi
+
+if [[ ${#COMMITS[@]} -eq 0 ]]; then
+  echo "check-shipped-on-main: no commits specified. Pass at least one SHA, branch, or HEAD." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Check each commit
+# ---------------------------------------------------------------------------
+any_not_on_main=0
+NOW=$(date +%s)
+
+for ref in "${COMMITS[@]}"; do
+  sha=$(git rev-parse "$ref" 2>/dev/null) || {
+    echo "check-shipped-on-main: cannot resolve '${ref}' — skipping" >&2
+    any_not_on_main=1
+    continue
+  }
+
+  short="${sha:0:8}"
+
+  if git merge-base --is-ancestor "$sha" origin/main 2>/dev/null; then
+    if [[ $VERBOSE -eq 1 ]]; then
+      echo "${short}: ON_MAIN"
+    fi
+  else
+    any_not_on_main=1
+    if [[ $VERBOSE -eq 1 ]]; then
+      # Compute age
+      commit_ts=$(git log -1 --format="%ct" "$sha" 2>/dev/null || echo "$NOW")
+      age_secs=$(( NOW - commit_ts ))
+      if [[ $age_secs -lt 3600 ]]; then
+        age="${age_secs}s ago"
+      elif [[ $age_secs -lt 86400 ]]; then
+        age="$(( age_secs / 3600 ))h ago"
+      else
+        age="$(( age_secs / 86400 ))d ago"
+      fi
+      echo "${short}: NOT_ON_MAIN (committed ${age})"
+    fi
+  fi
+done
+
+exit $any_not_on_main

--- a/plugins/coordinator/bin/coordinator-safe-commit
+++ b/plugins/coordinator/bin/coordinator-safe-commit
@@ -51,6 +51,11 @@ Usage:
   coordinator-safe-commit --blanket "<subject>"
   coordinator-safe-commit --scope-from <handoff.md> "<subject>"
   coordinator-safe-commit --dry-run "<subject>"
+
+Tip: If you're not sure what will be committed, run with --dry-run first.
+     Files being skipped as "owned by another session" but you wrote them?
+     Your session ID resolution is wrong — see
+     ~/.claude/docs/wiki/scoped-safety-commits.md (troubleshooting section).
 USAGE
   exit 1
 }
@@ -109,6 +114,62 @@ fi
 # Session ID resolution
 # ---------------------------------------------------------------------------
 
+# _pid_get_parent <pid>: print the parent PID of <pid>, or "" on failure.
+# Works on Linux (/proc), macOS, and Git Bash on Windows (ps -p ... -o ppid=).
+_pid_get_parent() {
+  local pid="${1:-}"
+  [[ -n "$pid" && "$pid" =~ ^[0-9]+$ ]] || return 1
+  local ppid=""
+  # /proc is available on Linux and Git Bash on Windows
+  if [[ -f "/proc/${pid}/status" ]]; then
+    ppid=$(grep -m1 '^PPid:' "/proc/${pid}/status" 2>/dev/null | awk '{print $2}' || true)
+  fi
+  # Fall back to ps (macOS, BSD)
+  if [[ -z "$ppid" ]]; then
+    ppid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ' || true)
+  fi
+  [[ -n "$ppid" && "$ppid" =~ ^[0-9]+$ ]] && echo "$ppid" || return 1
+}
+
+# _ppid_ancestry: print the ancestry chain of PIDs from $PPID upward, one per
+# line, stopping at PID 1 or after at most MAX_DEPTH steps. Used by both the
+# sentinel cross-check (W1.1) and the PPID-walk priority (W1.3).
+# Spec backlink: plan W1.1 sentinel cross-check + W1.3 PPID-walk discovery.
+_ppid_ancestry() {
+  local current="$PPID"
+  local depth=0
+  local max_depth=20
+  while [[ -n "$current" && "$current" =~ ^[0-9]+$ && "$current" -gt 1 && "$depth" -lt "$max_depth" ]]; do
+    echo "$current"
+    current=$(_pid_get_parent "$current" 2>/dev/null || true)
+    (( depth++ )) || true
+  done
+}
+
+# _session_pid_matches_ancestor <sessions_dir> <session_id>
+# Returns 0 if meta.json.pid for the given session is alive AND appears in
+# this process's PPID ancestry chain. Returns 1 otherwise.
+# Used by W1.1 sentinel cross-check.
+_session_pid_matches_ancestor() {
+  local base="${1:?}" sid="${2:?}"
+  local sdir="${base}/${sid}"
+  [[ -d "$sdir" ]] || return 1
+
+  local recorded_pid
+  recorded_pid=$(_cs_read_meta_field "$sdir" "pid")
+  [[ -n "$recorded_pid" && "$recorded_pid" =~ ^[0-9]+$ ]] || return 1
+
+  # Check liveness first (fast exit for dead PIDs)
+  _cs_pid_alive "$recorded_pid" || return 1
+
+  # Check that the recorded PID appears in our PPID ancestry chain
+  local ancestor
+  while IFS= read -r ancestor; do
+    [[ "$ancestor" == "$recorded_pid" ]] && return 0
+  done < <(_ppid_ancestry)
+  return 1
+}
+
 resolve_session_id() {
   # Priority 1: environment variable
   if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
@@ -116,26 +177,131 @@ resolve_session_id() {
     return 0
   fi
 
-  # Priority 2: sentinel file
+  local base
+  base=$(_cs_sessions_dir) || true
+
+  # Priority 1.5: PPID-walk — walk $PPID upward; for each ancestor, check if
+  # any live session's meta.json.pid matches. If exactly one match, use it.
+  # This is the highest-leverage resolution path when CLAUDE_SESSION_ID is unset:
+  # track-touched-files.sh (W1.0b) records a live $PPID on every hook invocation,
+  # giving us a reliable ancestor to find.
+  # Spec backlink: plan W1.3 — PPID-based discovery as priority 1.5.
+  # NO CLI-token fallback: the Bash tool spawns shells without session-identifiable tokens.
+  if [[ -n "$base" && -d "$base" ]]; then
+    local ppid_matched_session=""
+    local ancestry_pids=()
+    # Collect ancestry into an array once to avoid re-walking per session
+    while IFS= read -r ancestor_pid; do
+      ancestry_pids+=("$ancestor_pid")
+    done < <(_ppid_ancestry)
+
+    if [[ ${#ancestry_pids[@]} -gt 0 ]]; then
+      for sdir in "${base}"/*/; do
+        [[ -d "$sdir" ]] || continue
+        local sid
+        sid=$(basename "$sdir")
+        [[ "$sid" == ".archive" ]] && continue
+
+        local recorded_pid
+        recorded_pid=$(_cs_read_meta_field "$sdir" "pid")
+        [[ -n "$recorded_pid" && "$recorded_pid" =~ ^[0-9]+$ ]] || continue
+        _cs_pid_alive "$recorded_pid" || continue
+
+        # Check ancestry match
+        local anc
+        for anc in "${ancestry_pids[@]}"; do
+          if [[ "$anc" == "$recorded_pid" ]]; then
+            if [[ -n "$ppid_matched_session" && "$ppid_matched_session" != "$sid" ]]; then
+              # Multiple sessions match PPID ancestry — cannot disambiguate; fall through
+              ppid_matched_session="__ambiguous__"
+              break 2
+            fi
+            ppid_matched_session="$sid"
+            break
+          fi
+        done
+      done
+    fi
+
+    if [[ -n "$ppid_matched_session" && "$ppid_matched_session" != "__ambiguous__" ]]; then
+      # Check sentinel for disagreement before accepting (W1.1 disagreement rule)
+      local root
+      root=$(_cs_git_root) || true
+      if [[ -n "$root" ]]; then
+        local sentinel="${root}/.git/coordinator-sessions/.current-session-id"
+        if [[ -f "$sentinel" ]]; then
+          local sentinel_sid
+          sentinel_sid=$(cat "$sentinel" 2>/dev/null | tr -d '[:space:]')
+          # Sentinel path-traversal validation (W1.1)
+          if [[ -n "$sentinel_sid" && ! "$sentinel_sid" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "[coordinator-session] WARN: sentinel contains invalid characters — ignoring (possible path-traversal)" >&2
+            sentinel_sid=""
+          fi
+          # Disagreement rule (Patrik finding #4): if sentinel names a different live
+          # session that also has a live PID, hard-fail rather than silently prefer one.
+          if [[ -n "$sentinel_sid" && "$sentinel_sid" != "$ppid_matched_session" ]]; then
+            local sentinel_sdir="${base}/${sentinel_sid}"
+            if [[ -d "$sentinel_sdir" ]]; then
+              local sentinel_pid
+              sentinel_pid=$(_cs_read_meta_field "$sentinel_sdir" "pid")
+              if [[ -n "$sentinel_pid" ]] && _cs_pid_alive "$sentinel_pid"; then
+                echo "ERROR: Session ID resolution conflict — PPID-walk resolves to '${ppid_matched_session}' but sentinel points to '${sentinel_sid}' (also live)." >&2
+                echo "       Cannot safely choose between them. Set CLAUDE_SESSION_ID explicitly, or use the explicit-path fallback:" >&2
+                echo "         git add -- <your-paths>" >&2
+                echo "         git commit -m \"<subject>\"" >&2
+                return 1
+              fi
+            fi
+          fi
+        fi
+      fi
+      echo "$ppid_matched_session"
+      return 0
+    fi
+  fi
+
+  # Priority 2: sentinel file + cross-check against PPID ancestry (W1.1)
+  # The sentinel is read only when PPID-walk found no match or was ambiguous.
+  # Path-traversal validation and ancestry cross-check guard against stale/wrong sentinels.
+  # Spec backlink: plan W1.1 — sentinel cross-check + path-traversal validation.
   local root
   root=$(_cs_git_root) || true
   if [[ -n "$root" ]]; then
     local sentinel="${root}/.git/coordinator-sessions/.current-session-id"
     if [[ -f "$sentinel" ]]; then
       local sid
-      sid=$(cat "$sentinel" | tr -d '[:space:]')
-      if [[ -n "$sid" ]]; then
-        echo "$sid"
-        return 0
+      sid=$(cat "$sentinel" 2>/dev/null | tr -d '[:space:]')
+
+      # W1.1: Path-traversal validation — sentinel must match safe identifier pattern
+      if [[ -n "$sid" && ! "$sid" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "[coordinator-session] WARN: sentinel value '${sid}' contains invalid characters (possible path-traversal attack) — treating as untrusted" >&2
+        sid=""
+      fi
+
+      if [[ -n "$sid" && -n "$base" && -d "$base" ]]; then
+        # W1.1: Cross-check — sentinel's session must have a live PID in our ancestry
+        if _session_pid_matches_ancestor "$base" "$sid"; then
+          echo "$sid"
+          return 0
+        else
+          echo "[coordinator-session] WARN: sentinel points to session '${sid}' but its PID is not a live ancestor of this process — treating sentinel as untrusted" >&2
+          # Fall through to Priority 3
+        fi
       fi
     fi
   fi
 
-  # Priority 3: find a session dir whose meta.json PID matches a live process
-  local base
-  base=$(_cs_sessions_dir) || true
+  # Priority 3: enumerate live sessions — hard-fail when multiple, accept when exactly one.
+  # Multi-live detection runs here rather than only at fall-through: if PPID-walk found
+  # nothing and sentinel was untrusted, multiple live sessions means we cannot safely
+  # auto-detect. Naming both candidates gives the user actionable information.
+  # Spec backlink: plan W1.2 — multi-live hard-fail moved earlier + both candidates named.
   if [[ -z "$base" || ! -d "$base" ]]; then
-    echo "" ; return 1
+    echo "ERROR: No session store found. Set CLAUDE_SESSION_ID or ensure a session was initialized." >&2
+    echo "Fallback: bypass the helper with explicit-path commit:" >&2
+    echo "  git add -- <your-paths>" >&2
+    echo "  git commit -m \"<subject>\"" >&2
+    return 1
   fi
 
   local live_sessions=()
@@ -153,19 +319,26 @@ resolve_session_id() {
   done
 
   if [[ ${#live_sessions[@]} -eq 1 ]]; then
+    # Priority 3a: exactly one live session — safe to auto-detect
     echo "${live_sessions[0]}"
     return 0
   elif [[ ${#live_sessions[@]} -eq 0 ]]; then
+    # Priority 3c: no live sessions found
     echo "ERROR: No live session found. Set CLAUDE_SESSION_ID or ensure a session was initialized." >&2
     echo "Fallback: bypass the helper with explicit-path commit:" >&2
     echo "  git add -- <your-paths>" >&2
     echo "  git commit -m \"<subject>\"" >&2
     return 1
   else
-    echo "ERROR: Multiple live sessions found — cannot auto-detect session ID. Set CLAUDE_SESSION_ID explicitly. Candidates: ${live_sessions[*]}" >&2
-    echo "If session-ownership is misidentifying your work (your files blocked, others' files swept), the safer fallback is to bypass the helper:" >&2
-    echo "  git add -- <your-paths>" >&2
-    echo "  git commit -m \"<subject>\"" >&2
+    # Priority 3b: multiple live sessions — hard-fail naming both candidates
+    local candidate_list
+    candidate_list=$(printf '%s, ' "${live_sessions[@]}")
+    candidate_list="${candidate_list%, }"
+    echo "ERROR: Multiple live sessions found — cannot auto-detect session ID." >&2
+    echo "       Candidates: ${candidate_list}" >&2
+    echo "       Set CLAUDE_SESSION_ID explicitly, or bypass the helper:" >&2
+    echo "         git add -- <your-paths>" >&2
+    echo "         git commit -m \"<subject>\"" >&2
     return 1
   fi
 }
@@ -246,9 +419,26 @@ parse_scope_from_frontmatter() {
 }
 
 # validate_pathspec <pathspec>
-# Returns 0 if git accepts it, 1 if malformed.
+# Returns 0 if the pathspec is safe and git accepts it, 1 if malformed or
+# contains a path-traversal attempt.
+# Spec backlink: plan W2.1 worker-baseline finding #3 — explicit reject for
+# ".." traversal and absolute paths; git ls-files returns empty for out-of-tree
+# paths rather than an error, so the rejection must be explicit here.
 validate_pathspec() {
   local ps="${1:?}"
+
+  # Reject path traversal: any component containing ".." can escape the repo root.
+  if [[ "$ps" == *".."* ]]; then
+    echo "ERROR: pathspec '${ps}' contains '..' (path traversal) — rejected" >&2
+    return 1
+  fi
+
+  # Reject absolute paths: they reference locations outside the working tree.
+  if [[ "$ps" == /* ]]; then
+    echo "ERROR: pathspec '${ps}' is an absolute path — rejected" >&2
+    return 1
+  fi
+
   git ls-files -- "$ps" >/dev/null 2>&1
 }
 
@@ -372,16 +562,21 @@ do_scope_from() {
     fi
   done
 
-  # 4. Expand handoff pathspecs to actual file list
-  local handoff_files=()
-  for ps in "${handoff_pathspecs[@]}"; do
-    while IFS= read -r f; do
-      [[ -n "$f" ]] && handoff_files+=("$f")
-    done < <(git ls-files -- "$ps" 2>/dev/null; git ls-files --others --exclude-standard -- "$ps" 2>/dev/null)
-  done
+  # 4. Expand handoff pathspecs to actual file list, applying one-tier membership
+  # invariant for untracked files.
+  #
+  # One-tier untracked-membership invariant (W2.1, Patrik finding #2):
+  #   - Tracked candidates (git ls-files): admitted unconditionally — they are
+  #     already in repo history and cannot be a concurrent-session footgun.
+  #   - Untracked candidates (git ls-files --others): MUST appear in THIS
+  #     session's touched.txt. If they don't, they are dropped here — before
+  #     the cross-session subtraction step — regardless of whether the pathspec
+  #     is a glob or a literal. A literal like "docs/plans/2026-05-01-mine.md"
+  #     can still collide with another session's untracked file at the same path;
+  #     glob detection alone does not prevent this.
+  # Spec backlink: plan W2.1 — one-tier untracked-membership invariant.
 
-  # 5. Build MY_SCOPE: (handoff_files ∪ touched.txt) − other_sessions
-  # First get my touched.txt
+  # Collect my touched.txt first — needed for the membership gate below.
   local my_touched=()
   local base
   base=$(_cs_sessions_dir) || true
@@ -394,9 +589,35 @@ do_scope_from() {
     fi
   fi
 
+  # Build membership lookup for O(1) checks.
+  declare -A my_touched_set
+  for t in "${my_touched[@]:-}"; do
+    [[ -n "$t" ]] && my_touched_set["$t"]=1
+  done
+
+  local handoff_files=()
+  for ps in "${handoff_pathspecs[@]}"; do
+    # Tracked files: admitted unconditionally.
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && handoff_files+=("$f")
+    done < <(git ls-files -- "$ps" 2>/dev/null)
+
+    # Untracked files: membership gate — must be in this session's touched.txt.
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      if [[ -v "my_touched_set[$f]" ]]; then
+        handoff_files+=("$f")
+      else
+        echo "skipping untracked ${f} — not in this session's touched.txt (W2.1 membership gate)" >&2
+      fi
+    done < <(git ls-files --others --exclude-standard -- "$ps" 2>/dev/null)
+  done
+
+  # 5. Build MY_SCOPE: (handoff_files ∪ touched.txt) − other_sessions
+
   # Union: handoff + touched (deduplicated)
   declare -A candidate_map
-  for f in "${handoff_files[@]}" "${my_touched[@]}"; do
+  for f in "${handoff_files[@]}" "${my_touched[@]:-}"; do
     [[ -n "$f" ]] && candidate_map["$f"]=1
   done
 
@@ -419,15 +640,29 @@ do_scope_from() {
   fi
 
   # Subtract other-session claims
+  # W3 (Patrik R1 finding #1): distinguish "another session owns this" from
+  # "stale self-claim" when CLAUDE_SESSION_ID is set but resolution diverged.
+  # Append "(your session=<resolved>)" for disambiguation in the normal case.
   local my_scope=()
+  local env_sid="${CLAUDE_SESSION_ID:-}"
   for candidate in "${!candidate_map[@]}"; do
     if [[ -v "other_claims[$candidate]" ]]; then
       other_excluded+=("$candidate")
-      echo "skipping ${candidate} — owned by session ${other_claims[$candidate]}" >&2
+      local claim_sid="${other_claims[$candidate]}"
+      if [[ -n "$env_sid" && "$claim_sid" == "$env_sid" ]]; then
+        echo "skipping ${candidate} — stale self-claim from this session (resolved=${session_id}, env=${env_sid}) — investigate session ID resolution" >&2
+      else
+        echo "skipping ${candidate} — owned by session ${claim_sid} (your session=${session_id})" >&2
+      fi
     else
       my_scope+=("$candidate")
     fi
   done
+
+  # W3 epilogue: when ≥1 file was excluded, point the user at the right diagnostic.
+  if [[ ${#other_excluded[@]} -gt 0 ]]; then
+    echo "  hint: if your files are being skipped as 'owned by another session' but you wrote them, your session ID resolution is wrong (see ~/.claude/docs/wiki/scoped-safety-commits.md troubleshooting)" >&2
+  fi
 
   if [[ "${MODE}" == "dry-run" ]]; then
     echo "DRY RUN — would stage:" >&2
@@ -437,7 +672,26 @@ do_scope_from() {
   fi
 
   if [[ ${#my_scope[@]} -eq 0 ]]; then
-    echo "ERROR: No staged scope detected for this session. Either nothing was touched, or the touch-tracker hook didn't fire. Run with --dry-run to inspect." >&2
+    if [[ ${#other_excluded[@]} -gt 0 ]]; then
+      # Every candidate from the handoff scope was claimed by other sessions — stale-claim case.
+      # Collect the distinct session IDs that claimed entries so the user can act on them.
+      declare -A claiming_sessions
+      for excl in "${other_excluded[@]}"; do
+        if [[ -v "other_claims[$excl]" ]]; then
+          claiming_sessions["${other_claims[$excl]}"]=1
+        fi
+      done
+      local claimant_list
+      claimant_list=$(printf '%s ' "${!claiming_sessions[@]}")
+      echo "ERROR: Every file in the handoff scope was claimed by other session(s): ${claimant_list}" >&2
+      echo "       Files excluded: $(printf '%s, ' "${other_excluded[@]}")" >&2
+      echo "       Your session: ${session_id}" >&2
+      echo "       If these files are yours, bypass the helper:" >&2
+      echo "         git add -- <your-paths>" >&2
+      echo "         git commit -m \"<subject>\"" >&2
+    else
+      echo "ERROR: No staged scope detected for this session. Either nothing was touched, or the touch-tracker hook didn't fire. Run with --dry-run to inspect." >&2
+    fi
     exit 1
   fi
 

--- a/plugins/coordinator/bin/lib/query-records.test.js
+++ b/plugins/coordinator/bin/lib/query-records.test.js
@@ -1,0 +1,90 @@
+'use strict';
+/**
+ * query-records.test.js — Tests for query-records.js argument parsing and core logic.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2
+ *
+ * Run with: node --test bin/lib/query-records.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const QUERY_RECORDS = path.resolve(__dirname, '..', 'query-records.js');
+const ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..'); // ~/.claude
+
+// ---------------------------------------------------------------------------
+// --key=value normalization (patrik R2 finding 4)
+// ---------------------------------------------------------------------------
+
+test('--key=value form accepted: --type=plan', () => {
+  // Should not exit 1 with "Unknown argument: --type=plan"
+  // Use a path that exists. If the repo root has no plans, output may be empty — that's fine.
+  // We just care that parsing doesn't error out.
+  let threw = false;
+  try {
+    execFileSync(process.execPath, [QUERY_RECORDS, '--type=plan', '--limit=1', '--root', ROOT], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    threw = true;
+    // Accept non-zero exit only if it's a data error (e.g., no records), not a parse error
+    assert.ok(
+      !err.stderr.includes('Unknown argument'),
+      `Should not get "Unknown argument" on --type=plan. stderr: ${err.stderr}`
+    );
+  }
+  // Either succeeded (threw=false) or failed for a non-parse reason
+});
+
+test('--key=value form: --type=plan --sort=-created --limit=5 parses identically to space-separated', () => {
+  const spaceArgs = ['--type', 'plan', '--sort', '-created', '--limit', '5', '--root', ROOT];
+  const equalsArgs = ['--type=plan', '--sort=-created', '--limit=5', '--root', ROOT];
+
+  let spaceOut, equalsOut;
+  try {
+    spaceOut = execFileSync(process.execPath, [QUERY_RECORDS, ...spaceArgs], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    spaceOut = e.stdout || '';
+    assert.ok(!e.stderr.includes('Unknown argument'), `space form parse error: ${e.stderr}`);
+  }
+
+  try {
+    equalsOut = execFileSync(process.execPath, [QUERY_RECORDS, ...equalsArgs], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    equalsOut = e.stdout || '';
+    assert.ok(!e.stderr.includes('Unknown argument'), `equals form parse error: ${e.stderr}`);
+  }
+
+  assert.strictEqual(spaceOut, equalsOut, '--key=value and --key value forms should produce identical output');
+});
+
+// ---------------------------------------------------------------------------
+// parseWhereExpr (exported — test directly)
+// ---------------------------------------------------------------------------
+
+test('parseWhereExpr: single equality clause', () => {
+  const { parseWhereExpr } = require('../query-records.js');
+  const clauses = parseWhereExpr('status=active');
+  assert.equal(clauses.length, 1);
+  assert.equal(clauses[0].op, '=');
+  assert.equal(clauses[0].field, 'status');
+  assert.equal(clauses[0].value, 'active');
+});
+
+test('parseWhereExpr: AND conjunction', () => {
+  const { parseWhereExpr } = require('../query-records.js');
+  const clauses = parseWhereExpr('status=active AND reviewer=patrik');
+  assert.equal(clauses.length, 2);
+  assert.equal(clauses[0].field, 'status');
+  assert.equal(clauses[1].field, 'reviewer');
+});

--- a/plugins/coordinator/bin/lib/schema.js
+++ b/plugins/coordinator/bin/lib/schema.js
@@ -1,0 +1,444 @@
+'use strict';
+/**
+ * schema.js — frontmatter schema loader and validator for coordinator tracked records.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W1
+ *
+ * Exports:
+ *   loadSchemas(schemasDir)        → { [name]: schema, _byGlob: [{glob, schemaName}] }
+ *   matchSchemaForPath(repoRel, schemas) → {schemaName, schema} | null
+ *   parseFrontmatter(content)      → {frontmatter, body}
+ *   validateFrontmatter(fm, schema) → {ok, errors}
+ *   validateLessonsFile(content, lessonSchema) → {ok, errors}
+ *
+ * No external dependencies — uses only Node built-ins. YAML parsing is limited to the
+ * frontmatter subset our schemas produce: scalar strings, inline lists, and one level of
+ * nested mapping (for type/values blocks). Complex YAML constructs are not supported.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Minimal YAML parser for schema files and frontmatter blocks
+// Handles: scalar key: value, list items (- val), one level of nested mapping.
+// Does NOT handle: anchors, multi-line strings, flow mappings beyond inline lists.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a YAML string into a plain JS object.
+ * Restricted to the subset used in coordinator schemas and frontmatter.
+ */
+function parseYaml(text) {
+  const lines = text.split('\n');
+  return parseYamlLines(lines, 0, 0).value;
+}
+
+/**
+ * Parse lines starting at `start` with expected indent `baseIndent`.
+ * Returns { value: object|array|scalar, nextLine: number }.
+ */
+function parseYamlLines(lines, start, baseIndent) {
+  const result = {};
+  let i = start;
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    const trimmed = raw.trimEnd();
+
+    // Skip blank lines and comments
+    if (trimmed === '' || trimmed.trimStart().startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const indent = raw.length - raw.trimStart().length;
+
+    // If we've dedented below base, stop
+    if (indent < baseIndent) {
+      break;
+    }
+
+    // List item at this level?
+    if (trimmed.trimStart().startsWith('- ') || trimmed.trimStart() === '-') {
+      // Caller expecting a list — signal via special return
+      return { value: parseList(lines, i, baseIndent), nextLine: skipPast(lines, i, baseIndent) };
+    }
+
+    // key: value mapping
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const rest = trimmed.slice(colonIdx + 1).trim();
+
+    if (rest === '' || rest.startsWith('#')) {
+      // Value is either null or a nested block on following lines
+      const nextLine = i + 1;
+      if (nextLine < lines.length) {
+        const nextTrimmed = lines[nextLine].trimEnd();
+        const nextIndent = nextTrimmed === '' ? baseIndent : lines[nextLine].length - lines[nextLine].trimStart().length;
+
+        if (nextIndent > indent && nextTrimmed !== '') {
+          // Nested block
+          const nested = parseYamlLines(lines, nextLine, nextIndent);
+          result[key] = nested.value;
+          i = nested.nextLine;
+          continue;
+        }
+      }
+      result[key] = null;
+    } else if (rest.startsWith('[') && rest.endsWith(']')) {
+      // Inline list: [a, b, c]
+      result[key] = parseInlineList(rest);
+    } else {
+      result[key] = parseScalar(rest);
+    }
+    i++;
+  }
+
+  return { value: result, nextLine: i };
+}
+
+function parseList(lines, start, baseIndent) {
+  const list = [];
+  let i = start;
+  while (i < lines.length) {
+    const raw = lines[i];
+    const trimmed = raw.trimEnd().trimStart();
+    if (trimmed === '' || trimmed.startsWith('#')) { i++; continue; }
+    const indent = raw.length - raw.trimStart().length;
+    if (indent < baseIndent) break;
+    if (trimmed.startsWith('- ')) {
+      list.push(parseScalar(trimmed.slice(2).trim()));
+    } else if (trimmed === '-') {
+      list.push(null);
+    } else {
+      break;
+    }
+    i++;
+  }
+  return list;
+}
+
+function skipPast(lines, start, baseIndent) {
+  let i = start;
+  while (i < lines.length) {
+    const raw = lines[i];
+    const trimmed = raw.trimEnd();
+    if (trimmed === '' || trimmed.startsWith('#')) { i++; continue; }
+    const indent = raw.length - raw.trimStart().length;
+    if (indent < baseIndent) break;
+    if (trimmed.trimStart().startsWith('- ') || trimmed.trimStart() === '-') {
+      i++;
+    } else {
+      break;
+    }
+  }
+  return i;
+}
+
+function parseInlineList(text) {
+  // "[a, b, c]" → ['a', 'b', 'c']
+  const inner = text.slice(1, -1);
+  return inner.split(',').map(s => parseScalar(s.trim())).filter(s => s !== null && s !== '');
+}
+
+function parseScalar(text) {
+  if (text === 'null' || text === '~') return null;
+  if (text === 'true') return true;
+  if (text === 'false') return false;
+  const n = Number(text);
+  if (!isNaN(n) && text !== '') return n;
+  // Strip surrounding quotes
+  if ((text.startsWith('"') && text.endsWith('"')) ||
+      (text.startsWith("'") && text.endsWith("'"))) {
+    return text.slice(1, -1);
+  }
+  return text;
+}
+
+// ---------------------------------------------------------------------------
+// Glob matcher — supports *, **, ? with no external deps
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a glob pattern to a RegExp. Handles *, **, ?.
+ * Uses posix-style / separators regardless of platform.
+ */
+function globToRegex(pattern) {
+  // Normalise separators
+  const p = pattern.replace(/\\/g, '/');
+  let re = '';
+  let i = 0;
+  while (i < p.length) {
+    const c = p[i];
+    if (c === '*' && p[i + 1] === '*') {
+      re += '.*';
+      i += 2;
+      if (p[i] === '/') i++; // consume trailing slash after **
+    } else if (c === '*') {
+      re += '[^/]*';
+      i++;
+    } else if (c === '?') {
+      re += '[^/]';
+      i++;
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      re += '\\' + c;
+      i++;
+    } else {
+      re += c;
+      i++;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+function matchGlob(pattern, filePath) {
+  const normalised = filePath.replace(/\\/g, '/');
+  return globToRegex(pattern).test(normalised);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load all *.yaml schema files from schemasDir.
+ * Returns { [schemaName]: parsedSchema, _byGlob: [{glob, schemaName}] }
+ */
+function loadSchemas(schemasDir) {
+  const schemas = { _byGlob: [] };
+  const files = fs.readdirSync(schemasDir).filter(f => f.endsWith('.yaml'));
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(schemasDir, file), 'utf8');
+    const parsed = parseYaml(raw);
+    const name = parsed.schema || path.basename(file, '.yaml');
+    schemas[name] = parsed;
+    if (parsed.applies_to) {
+      schemas._byGlob.push({ glob: parsed.applies_to, schemaName: name });
+    }
+  }
+  return schemas;
+}
+
+/**
+ * Find the schema that matches repoRelPath.
+ * repoRelPath should use forward slashes (e.g. "tasks/handoffs/foo.md").
+ * Returns {schemaName, schema} or null.
+ */
+function matchSchemaForPath(repoRelPath, schemas) {
+  const normalised = repoRelPath.replace(/\\/g, '/');
+  for (const { glob, schemaName } of schemas._byGlob) {
+    if (matchGlob(glob, normalised)) {
+      return { schemaName, schema: schemas[schemaName] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract YAML frontmatter from markdown content.
+ * Expects optional "---\n...\n---\n" delimiters at the start.
+ * Returns {frontmatter: object|null, body: string}.
+ */
+function parseFrontmatter(content) {
+  if (!content.startsWith('---')) {
+    return { frontmatter: null, body: content };
+  }
+  const afterFirst = content.slice(3);
+  // Allow optional \r after ---
+  const firstNewline = afterFirst.indexOf('\n');
+  if (firstNewline === -1) {
+    return { frontmatter: null, body: content };
+  }
+  // Find closing ---
+  const rest = afterFirst.slice(firstNewline + 1);
+  const closeIdx = rest.search(/^---\s*$/m);
+  if (closeIdx === -1) {
+    return { frontmatter: null, body: content };
+  }
+  const yamlBlock = rest.slice(0, closeIdx);
+  const body = rest.slice(closeIdx).replace(/^---\s*\n?/, '');
+  try {
+    const fm = parseYaml(yamlBlock);
+    return { frontmatter: fm, body };
+  } catch {
+    return { frontmatter: null, body: content };
+  }
+}
+
+/**
+ * Validate a frontmatter object against a schema.
+ * Returns {ok: true} or {ok: false, errors: [{field, error, hint}]}.
+ * Permissive on optional fields; only validates required.
+ */
+function validateFrontmatter(frontmatter, schema) {
+  if (!schema || !schema.required) {
+    return { ok: true };
+  }
+  if (!frontmatter) {
+    return {
+      ok: false,
+      errors: [{ field: '(frontmatter)', error: 'missing frontmatter block', hint: 'Add --- delimited YAML frontmatter at the top of the file' }]
+    };
+  }
+
+  const errors = [];
+  for (const [field, spec] of Object.entries(schema.required)) {
+    const value = frontmatter[field];
+
+    // For string-or-null fields, explicit null is a valid value — don't treat as missing.
+    const isStringOrNull = spec && typeof spec === 'object' && spec.type === 'string-or-null';
+    const isMissing = value === undefined || (value === null && !isStringOrNull);
+
+    if (isMissing) {
+      errors.push({ field, error: 'required field missing', hint: `Add "${field}:" to frontmatter` });
+      continue;
+    }
+
+    if (typeof spec === 'string') {
+      // Simple type check
+      const typeErr = checkType(field, value, spec);
+      if (typeErr) errors.push(typeErr);
+    } else if (spec && typeof spec === 'object') {
+      const type = spec.type;
+      if (type === 'enum') {
+        const allowed = spec.values || [];
+        if (!allowed.includes(String(value))) {
+          errors.push({
+            field,
+            error: `invalid enum value "${value}"`,
+            hint: `Allowed values: ${allowed.join(', ')}`
+          });
+        }
+      } else if (type === 'string-or-null') {
+        if (value !== null && typeof value !== 'string') {
+          errors.push({ field, error: `expected string or null, got ${typeof value}`, hint: `Set to a string or null` });
+        }
+      } else if (type === 'list-of-string') {
+        if (!Array.isArray(value)) {
+          errors.push({ field, error: 'expected a list', hint: `Use YAML list syntax, e.g. ["name"]` });
+        } else {
+          const bad = value.filter(v => typeof v !== 'string');
+          if (bad.length > 0) {
+            errors.push({ field, error: 'list contains non-string items', hint: 'All list items must be strings' });
+          }
+        }
+      } else if (type === 'number') {
+        if (typeof value !== 'number') {
+          errors.push({ field, error: `expected number, got ${typeof value}`, hint: 'Provide a numeric value' });
+        }
+      } else {
+        // Treat as simple type string
+        const typeErr = checkType(field, value, type);
+        if (typeErr) errors.push(typeErr);
+      }
+    }
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}
+
+function checkType(field, value, type) {
+  if (type === 'string') {
+    if (typeof value !== 'string') {
+      return { field, error: `expected string, got ${typeof value}`, hint: `Provide a string value for "${field}"` };
+    }
+  } else if (type === 'iso-date') {
+    if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}/.test(value)) {
+      return { field, error: `expected ISO date (YYYY-MM-DD), got "${value}"`, hint: 'Use format YYYY-MM-DD' };
+    }
+  } else if (type === 'number') {
+    if (typeof value !== 'number') {
+      return { field, error: `expected number, got ${typeof value}`, hint: 'Provide a numeric value' };
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate a lessons.md file against the lesson-entry schema.
+ * Each **bold-title** entry may carry a [universal] or [project] tag.
+ * Unknown tags (not in tag_enum.values) are rejected; untagged entries are allowed.
+ *
+ * Returns {ok: boolean, errors: [{line, field, error, hint}]}.
+ */
+function validateLessonsFile(content, lessonSchema) {
+  if (!lessonSchema || lessonSchema.match_mode !== 'inline-tag-per-entry') {
+    return { ok: true };
+  }
+
+  const allowedTags = (lessonSchema.tag_enum && lessonSchema.tag_enum.values) || [];
+  const untaggedAllowed = lessonSchema.tag_enum && lessonSchema.tag_enum.untagged_allowed !== false;
+
+  const errors = [];
+  const lines = content.split('\n');
+
+  // Match bold-title entry lines: **Some Title**
+  const entryRe = /^\s*[-*]?\s*\*\*[^*]+\*\*/;
+  // Match tags like [universal] or [project] within a line
+  const tagRe = /\[([^\]]+)\]/g;
+  // Strip inline code spans (`...`) and markdown link text (`[text](url)`) before
+  // tag-matching so model-ID literals like `claude-opus-4-7[1m]` and link text
+  // like `[some link](url)` aren't mistaken for tags. Code-span match is
+  // non-greedy and tolerant of doubled backticks; link-text strip removes the
+  // bracketed portion of `[…](…)` constructs.
+  const stripNoise = (s) =>
+    s.replace(/``[^`]*``/g, ' ').replace(/`[^`]*`/g, ' ').replace(/\[[^\]]*\]\([^)]*\)/g, ' ');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!entryRe.test(line)) continue;
+
+    // Collect all bracket-enclosed tokens on this line, ignoring those inside
+    // code spans or markdown link text.
+    const scrubbed = stripNoise(line);
+    const tags = [];
+    let m;
+    tagRe.lastIndex = 0;
+    while ((m = tagRe.exec(scrubbed)) !== null) {
+      tags.push(m[1]);
+    }
+
+    if (tags.length === 0) {
+      // Untagged entry — ok if untagged_allowed
+      if (!untaggedAllowed) {
+        errors.push({
+          line: i + 1,
+          field: 'tag',
+          error: 'entry has no tag',
+          hint: `Add [${allowedTags.join('|')}] to the entry line`
+        });
+      }
+    } else {
+      // Validate each tag
+      for (const tag of tags) {
+        if (!allowedTags.includes(tag)) {
+          errors.push({
+            line: i + 1,
+            field: 'tag',
+            error: `unknown tag "[${tag}]"`,
+            hint: `Allowed tags: ${allowedTags.map(t => '[' + t + ']').join(', ')}`
+          });
+        }
+      }
+    }
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}
+
+module.exports = {
+  loadSchemas,
+  matchSchemaForPath,
+  parseFrontmatter,
+  validateFrontmatter,
+  validateLessonsFile,
+  // Exported for testing
+  _parseYaml: parseYaml,
+  _matchGlob: matchGlob,
+};

--- a/plugins/coordinator/bin/lib/schema.test.js
+++ b/plugins/coordinator/bin/lib/schema.test.js
@@ -1,0 +1,389 @@
+'use strict';
+/**
+ * schema.test.js — unit tests for bin/lib/schema.js
+ *
+ * Run with: node --test bin/lib/schema.test.js
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W1 Tests
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const {
+  loadSchemas,
+  matchSchemaForPath,
+  parseFrontmatter,
+  validateFrontmatter,
+  validateLessonsFile,
+  _parseYaml,
+  _matchGlob,
+} = require('./schema.js');
+
+const SCHEMAS_DIR = path.resolve(__dirname, '../../schemas');
+
+// Load schemas once at module scope — shared across all describe blocks.
+// This avoids needing before() hooks and is safe because loadSchemas is pure.
+const SCHEMAS = loadSchemas(SCHEMAS_DIR);
+
+// ---------------------------------------------------------------------------
+// loadSchemas / matchSchemaForPath
+// ---------------------------------------------------------------------------
+
+describe('loadSchemas', () => {
+  it('loads all six schemas', () => {
+    const names = Object.keys(SCHEMAS).filter(k => k !== '_byGlob');
+    assert.ok(names.includes('handoff'), 'handoff schema missing');
+    assert.ok(names.includes('decision'), 'decision schema missing');
+    assert.ok(names.includes('plan'), 'plan schema missing');
+    assert.ok(names.includes('review'), 'review schema missing');
+    assert.ok(names.includes('worker-run'), 'worker-run schema missing');
+    assert.ok(names.includes('lesson-entry'), 'lesson-entry schema missing');
+    assert.equal(names.length, 6, `expected 6 schemas, got ${names.length}`);
+  });
+
+  it('_byGlob index has an entry per applies_to schema', () => {
+    assert.ok(SCHEMAS._byGlob.length >= 5, '_byGlob should have at least 5 glob entries');
+  });
+});
+
+describe('matchSchemaForPath', () => {
+  it('tasks/handoffs/foo.md → handoff schema', () => {
+    const match = matchSchemaForPath('tasks/handoffs/foo.md', SCHEMAS);
+    assert.ok(match !== null, 'expected a match');
+    assert.equal(match.schemaName, 'handoff');
+  });
+
+  it('tasks/handoffs/sub/foo.md → no match (single-star glob)', () => {
+    const match = matchSchemaForPath('tasks/handoffs/sub/foo.md', SCHEMAS);
+    assert.equal(match, null, 'sub-path should not match single-star glob');
+  });
+
+  it('docs/plans/2026-05-01-foo.md → plan schema', () => {
+    const match = matchSchemaForPath('docs/plans/2026-05-01-foo.md', SCHEMAS);
+    assert.ok(match !== null);
+    assert.equal(match.schemaName, 'plan');
+  });
+
+  it('tasks/reviews/2026-05-01-review.md → review schema', () => {
+    const match = matchSchemaForPath('tasks/reviews/2026-05-01-review.md', SCHEMAS);
+    assert.ok(match !== null);
+    assert.equal(match.schemaName, 'review');
+  });
+
+  it('tasks/worker-runs/2026-05-01-run.md → worker-run schema', () => {
+    const match = matchSchemaForPath('tasks/worker-runs/2026-05-01-run.md', SCHEMAS);
+    assert.ok(match !== null);
+    assert.equal(match.schemaName, 'worker-run');
+  });
+
+  it('docs/wiki/some-guide.md → no match', () => {
+    const match = matchSchemaForPath('docs/wiki/some-guide.md', SCHEMAS);
+    assert.equal(match, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFrontmatter
+// ---------------------------------------------------------------------------
+
+describe('parseFrontmatter', () => {
+  it('parses standard frontmatter block', () => {
+    const content = `---\ntitle: Test\ncreated: 2026-05-01\n---\n# Body\n`;
+    const { frontmatter, body } = parseFrontmatter(content);
+    assert.equal(frontmatter.title, 'Test');
+    assert.equal(frontmatter.created, '2026-05-01');
+    assert.ok(body.includes('# Body'));
+  });
+
+  it('returns null frontmatter when no delimiter present', () => {
+    const content = `# Just markdown\nNo frontmatter here.\n`;
+    const { frontmatter, body } = parseFrontmatter(content);
+    assert.equal(frontmatter, null);
+    assert.equal(body, content);
+  });
+
+  it('parses list fields', () => {
+    const content = `---\ntitle: A\ndeciders:\n  - alice\n  - bob\n---\nbody\n`;
+    const { frontmatter } = parseFrontmatter(content);
+    assert.deepEqual(frontmatter.deciders, ['alice', 'bob']);
+  });
+
+  it('parses null/string-or-null field', () => {
+    const content = `---\ntitle: A\npredecessor: null\n---\n`;
+    const { frontmatter } = parseFrontmatter(content);
+    assert.equal(frontmatter.predecessor, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateFrontmatter — handoff schema
+// ---------------------------------------------------------------------------
+
+describe('validateFrontmatter — handoff', () => {
+  const handoffSchema = SCHEMAS['handoff'];
+
+  it('valid handoff frontmatter passes', () => {
+    const fm = {
+      title: 'Test handoff',
+      created: '2026-05-01',
+      branch: 'work/57754134/2026-05-01-test',
+      status: 'active',
+      predecessor: null,
+    };
+    const result = validateFrontmatter(fm, handoffSchema);
+    assert.ok(result.ok, `Expected ok, got errors: ${JSON.stringify(result.errors)}`);
+  });
+
+  it('missing branch fails with field-level error', () => {
+    const fm = {
+      title: 'Test handoff',
+      created: '2026-05-01',
+      status: 'active',
+      predecessor: null,
+      // branch omitted
+    };
+    const result = validateFrontmatter(fm, handoffSchema);
+    assert.equal(result.ok, false);
+    const branchErr = result.errors.find(e => e.field === 'branch');
+    assert.ok(branchErr, `Expected branch error, got: ${JSON.stringify(result.errors)}`);
+    assert.match(branchErr.error, /missing/);
+  });
+
+  it('wrong status enum value fails', () => {
+    const fm = {
+      title: 'Test handoff',
+      created: '2026-05-01',
+      branch: 'work/test',
+      status: 'open',    // invalid — not in [active, consumed, superseded]
+      predecessor: null,
+    };
+    const result = validateFrontmatter(fm, handoffSchema);
+    assert.equal(result.ok, false);
+    const statusErr = result.errors.find(e => e.field === 'status');
+    assert.ok(statusErr, `Expected status error, got: ${JSON.stringify(result.errors)}`);
+    assert.match(statusErr.hint, /active/);
+  });
+
+  it('null predecessor passes (string-or-null)', () => {
+    const fm = {
+      title: 'Test',
+      created: '2026-05-01',
+      branch: 'work/test',
+      status: 'consumed',
+      predecessor: null,
+    };
+    const result = validateFrontmatter(fm, handoffSchema);
+    assert.ok(result.ok);
+  });
+
+  it('string predecessor passes (string-or-null)', () => {
+    const fm = {
+      title: 'Test',
+      created: '2026-05-01',
+      branch: 'work/test',
+      status: 'consumed',
+      predecessor: 'tasks/handoffs/2026-04-30-prev.md',
+    };
+    const result = validateFrontmatter(fm, handoffSchema);
+    assert.ok(result.ok);
+  });
+
+  it('invalid date format fails', () => {
+    const fm = {
+      title: 'Test',
+      created: '01-05-2026',   // wrong format
+      branch: 'work/test',
+      status: 'active',
+      predecessor: null,
+    };
+    const result = validateFrontmatter(fm, handoffSchema);
+    assert.equal(result.ok, false);
+    const dateErr = result.errors.find(e => e.field === 'created');
+    assert.ok(dateErr, 'Expected created date error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateFrontmatter — decision schema (list-of-string)
+// ---------------------------------------------------------------------------
+
+describe('validateFrontmatter — decision', () => {
+  const decisionSchema = SCHEMAS['decision'];
+
+  it('valid decision with list deciders passes', () => {
+    const fm = {
+      title: 'Use Node over shell',
+      created: '2026-05-01',
+      status: 'accepted',
+      deciders: ['donal', 'patrik'],
+    };
+    const result = validateFrontmatter(fm, decisionSchema);
+    assert.ok(result.ok);
+  });
+
+  it('deciders as scalar (not list) fails', () => {
+    const fm = {
+      title: 'Use Node over shell',
+      created: '2026-05-01',
+      status: 'accepted',
+      deciders: 'donal',
+    };
+    const result = validateFrontmatter(fm, decisionSchema);
+    assert.equal(result.ok, false);
+    const err = result.errors.find(e => e.field === 'deciders');
+    assert.ok(err);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateFrontmatter — review schema (findings_count: number)
+// ---------------------------------------------------------------------------
+
+describe('validateFrontmatter — review', () => {
+  const reviewSchema = SCHEMAS['review'];
+
+  it('valid review passes', () => {
+    const fm = {
+      title: 'R1 safe-commit review',
+      created: '2026-05-01',
+      reviewer: 'patrik',
+      target: 'bin/coordinator-safe-commit',
+      findings_count: 7,
+    };
+    const result = validateFrontmatter(fm, reviewSchema);
+    assert.ok(result.ok);
+  });
+
+  it('invalid reviewer enum fails', () => {
+    const fm = {
+      title: 'R1',
+      created: '2026-05-01',
+      reviewer: 'unknown-reviewer',
+      target: 'bin/foo',
+      findings_count: 0,
+    };
+    const result = validateFrontmatter(fm, reviewSchema);
+    assert.equal(result.ok, false);
+    const err = result.errors.find(e => e.field === 'reviewer');
+    assert.ok(err);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateLessonsFile
+// ---------------------------------------------------------------------------
+
+describe('validateLessonsFile', () => {
+  const lessonSchema = SCHEMAS['lesson-entry'];
+
+  it('one untagged + one [universal] entry passes', () => {
+    const content = [
+      '# Lessons',
+      '',
+      '- **Always commit small chunks** — keeps diffs reviewable.',
+      '',
+      '- **[universal] Schema what you query** — YAGNI for schemas.',
+      '',
+    ].join('\n');
+    const result = validateLessonsFile(content, lessonSchema);
+    assert.ok(result.ok, `Expected ok, got: ${JSON.stringify(result.errors)}`);
+  });
+
+  it('[project] tag is also valid', () => {
+    const content = [
+      '- **[project] Repo-specific tip** — only relevant here.',
+    ].join('\n');
+    const result = validateLessonsFile(content, lessonSchema);
+    assert.ok(result.ok);
+  });
+
+  it('[whatever] invalid tag fails', () => {
+    const content = [
+      '- **[whatever] Bad tag** — this tag is not in the enum.',
+    ].join('\n');
+    const result = validateLessonsFile(content, lessonSchema);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.length > 0);
+    assert.match(result.errors[0].error, /unknown tag/);
+    assert.match(result.errors[0].hint, /universal/);
+  });
+
+  it('multiple invalid tags in same file accumulate errors', () => {
+    const content = [
+      '- **[deprecated] Old tag** — was once allowed.',
+      '- **[tier-1] Another bad tag** — not in enum.',
+    ].join('\n');
+    const result = validateLessonsFile(content, lessonSchema);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.length >= 2);
+  });
+
+  it('empty file passes', () => {
+    const result = validateLessonsFile('', lessonSchema);
+    assert.ok(result.ok);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _matchGlob — unit tests for the glob matcher
+// ---------------------------------------------------------------------------
+
+describe('_matchGlob', () => {
+  it('* matches a single path segment', () => {
+    assert.ok(_matchGlob('tasks/handoffs/*.md', 'tasks/handoffs/foo.md'));
+  });
+
+  it('* does not match across directories', () => {
+    assert.ok(!_matchGlob('tasks/handoffs/*.md', 'tasks/handoffs/sub/foo.md'));
+  });
+
+  it('** matches across directories', () => {
+    assert.ok(_matchGlob('tasks/**/*.md', 'tasks/handoffs/sub/foo.md'));
+  });
+
+  it('exact path matches itself', () => {
+    assert.ok(_matchGlob('tasks/lessons.md', 'tasks/lessons.md'));
+  });
+
+  it('? matches a single non-separator char', () => {
+    assert.ok(_matchGlob('tasks/?.md', 'tasks/a.md'));
+    assert.ok(!_matchGlob('tasks/?.md', 'tasks/ab.md'));
+  });
+
+  it('Windows backslash paths are normalised', () => {
+    assert.ok(_matchGlob('tasks/handoffs/*.md', 'tasks\\handoffs\\foo.md'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _parseYaml — basic sanity on internal parser
+// ---------------------------------------------------------------------------
+
+describe('_parseYaml', () => {
+  it('parses simple key-value pairs', () => {
+    const result = _parseYaml('schema: handoff\napplies_to: "tasks/handoffs/*.md"\n');
+    assert.equal(result.schema, 'handoff');
+    assert.equal(result.applies_to, 'tasks/handoffs/*.md');
+  });
+
+  it('parses nested required block', () => {
+    const yaml = [
+      'required:',
+      '  title: string',
+      '  status:',
+      '    type: enum',
+      '    values: [active, consumed]',
+    ].join('\n');
+    const result = _parseYaml(yaml);
+    assert.equal(result.required.title, 'string');
+    assert.equal(result.required.status.type, 'enum');
+    assert.deepEqual(result.required.status.values, ['active', 'consumed']);
+  });
+
+  it('parses list items', () => {
+    const yaml = 'items:\n  - foo\n  - bar\n';
+    const result = _parseYaml(yaml);
+    assert.deepEqual(result.items, ['foo', 'bar']);
+  });
+});

--- a/plugins/coordinator/bin/lib/sentinel-blocks-cli.js
+++ b/plugins/coordinator/bin/lib/sentinel-blocks-cli.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * sentinel-blocks-cli.js — Thin CLI wrapper around sentinel-blocks.js for use in shell scripts.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2
+ *
+ * Commands:
+ *   extract <file> <begin-marker> <end-marker>
+ *     Prints the block content between markers (exclusive — marker lines not included) to stdout.
+ *     Exits 1 if either marker is absent.
+ *
+ * Review: patrik R2 finding 0 — factor shared extraction primitive used by verify-preamble-sync.sh
+ * and verify-calibration-sync.sh so all three implementations converge on one source of truth.
+ */
+
+const fs = require('fs');
+const { extractBlock } = require('./sentinel-blocks.js');
+
+function usage() {
+  process.stderr.write(
+    'Usage: sentinel-blocks-cli.js extract <file> <begin-marker> <end-marker>\n'
+  );
+  process.exit(1);
+}
+
+const [,, command, ...rest] = process.argv;
+
+if (!command) usage();
+
+switch (command) {
+  case 'extract': {
+    const [file, beginMarker, endMarker] = rest;
+    if (!file || !beginMarker || !endMarker) usage();
+
+    let content;
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch (err) {
+      process.stderr.write(`sentinel-blocks-cli: cannot read file: ${file}: ${err.message}\n`);
+      process.exit(1);
+    }
+
+    const result = extractBlock(content, beginMarker, endMarker);
+    if (!result) {
+      process.stderr.write(
+        `sentinel-blocks-cli: markers not found in ${file}\n` +
+        `  begin: ${beginMarker}\n` +
+        `  end:   ${endMarker}\n`
+      );
+      process.exit(1);
+    }
+
+    process.stdout.write(result.block);
+    break;
+  }
+
+  default:
+    process.stderr.write(`sentinel-blocks-cli: unknown command: ${command}\n`);
+    usage();
+}

--- a/plugins/coordinator/bin/lib/sentinel-blocks.js
+++ b/plugins/coordinator/bin/lib/sentinel-blocks.js
@@ -1,0 +1,144 @@
+'use strict';
+/**
+ * sentinel-blocks.js — Extract and replace sentinel-delimited blocks in markdown content.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2 (Sentinel-Block Primitives)
+ *
+ * Exports:
+ *   extractBlock(content, beginMarker, endMarker) → {block, before, after} | null
+ *   replaceBlock(content, beginMarker, endMarker, newBlockContent) → string | null
+ *   insertOrReplaceBlock(content, beginMarker, endMarker, newBlockContent, insertAt) → string
+ *
+ * All ops use plain string index lookups — no regex — so markers with special chars work safely.
+ * Markers are treated as exact substrings. Typical form: <!-- BEGIN x --> / <!-- END x -->.
+ *
+ * Line-boundary handling: if a marker sits at the start of its line (possibly after whitespace),
+ * the surrounding newlines are consumed so that the extracted block / replacement is clean.
+ */
+
+/**
+ * Find begin/end marker positions, handling both "marker on its own line" and inline cases.
+ * Returns { beginStart, beginEnd, endStart, endEnd } (all byte offsets into `content`), or null.
+ *
+ * beginStart — index of the first character of the begin marker line (or the marker itself)
+ * beginEnd   — index just after the end of the begin marker (including its trailing newline if any)
+ * endStart   — index of the first character of the end marker line (or the marker itself)
+ * endEnd     — index just after the end of the end marker (including its trailing newline if any)
+ */
+function findMarkers(content, beginMarker, endMarker) {
+  const bi = content.indexOf(beginMarker);
+  if (bi === -1) return null;
+
+  const ei = content.indexOf(endMarker, bi + beginMarker.length);
+  if (ei === -1) return null;
+
+  // Determine line extents for begin marker
+  let beginLineStart = bi;
+  while (beginLineStart > 0 && content[beginLineStart - 1] !== '\n') {
+    beginLineStart--;
+  }
+  let beginLineEnd = bi + beginMarker.length;
+  // Consume trailing newline (including \r\n)
+  if (content[beginLineEnd] === '\r') beginLineEnd++;
+  if (content[beginLineEnd] === '\n') beginLineEnd++;
+
+  // Determine line extents for end marker
+  let endLineStart = ei;
+  while (endLineStart > 0 && content[endLineStart - 1] !== '\n') {
+    endLineStart--;
+  }
+  let endLineEnd = ei + endMarker.length;
+  if (content[endLineEnd] === '\r') endLineEnd++;
+  if (content[endLineEnd] === '\n') endLineEnd++;
+
+  // Only use line extents if the text before the marker on its line is whitespace-only.
+  // If there's non-whitespace before the marker, treat as inline — use raw positions.
+  const textBeforeBegin = content.slice(beginLineStart, bi);
+  const textBeforeEnd = content.slice(endLineStart, ei);
+
+  const beginIsOwnLine = textBeforeBegin.trim() === '';
+  const endIsOwnLine = textBeforeEnd.trim() === '';
+
+  return {
+    beginStart: beginIsOwnLine ? beginLineStart : bi,
+    beginEnd:   beginIsOwnLine ? beginLineEnd   : bi + beginMarker.length,
+    endStart:   endIsOwnLine   ? endLineStart   : ei,
+    endEnd:     endIsOwnLine   ? endLineEnd     : ei + endMarker.length,
+  };
+}
+
+/**
+ * Extract the content between beginMarker and endMarker.
+ *
+ * Returns { block, before, after } where:
+ *   block  — the text between the two markers (not including marker lines themselves)
+ *   before — the text before (and including) the begin marker line
+ *   after  — the text from (and including) the end marker line to end of file
+ *
+ * Returns null if either marker is not found.
+ */
+function extractBlock(content, beginMarker, endMarker) {
+  const pos = findMarkers(content, beginMarker, endMarker);
+  if (!pos) return null;
+
+  const before = content.slice(0, pos.beginEnd);
+  const block = content.slice(pos.beginEnd, pos.endStart);
+  const after = content.slice(pos.endStart);
+
+  return { block, before, after };
+}
+
+/**
+ * Replace the block content between beginMarker and endMarker with newBlockContent.
+ *
+ * Preserves the marker lines themselves. newBlockContent is placed verbatim between them;
+ * a trailing newline is added before the end marker if newBlockContent doesn't end with one.
+ *
+ * Returns the updated string, or null if either marker is missing.
+ */
+function replaceBlock(content, beginMarker, endMarker, newBlockContent) {
+  const pos = findMarkers(content, beginMarker, endMarker);
+  if (!pos) return null;
+
+  // Reconstruct: everything up to (and including) begin marker line, then new content,
+  // then end marker line to end of file.
+  const head = content.slice(0, pos.beginEnd);
+  const tail = content.slice(pos.endStart);
+
+  // Ensure newBlockContent ends with newline so end marker starts on its own line
+  let body = newBlockContent;
+  if (body.length > 0 && !body.endsWith('\n')) {
+    body += '\n';
+  }
+
+  return head + body + tail;
+}
+
+/**
+ * Like replaceBlock, but if the markers don't exist, insert them.
+ *
+ * insertAt: 'end' (default) appends the block at the end of content.
+ *           'start' prepends at the beginning.
+ *
+ * Returns the updated string (never null).
+ */
+function insertOrReplaceBlock(content, beginMarker, endMarker, newBlockContent, insertAt = 'end') {
+  const replaced = replaceBlock(content, beginMarker, endMarker, newBlockContent);
+  if (replaced !== null) return replaced;
+
+  // Markers missing — insert them
+  let body = newBlockContent;
+  if (body.length > 0 && !body.endsWith('\n')) {
+    body += '\n';
+  }
+  const block = beginMarker + '\n' + body + endMarker + '\n';
+
+  if (insertAt === 'start') {
+    return block + content;
+  }
+  // 'end' — ensure there's a newline separator
+  const sep = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+  return content + sep + block;
+}
+
+module.exports = { extractBlock, replaceBlock, insertOrReplaceBlock };

--- a/plugins/coordinator/bin/lib/sentinel-blocks.test.js
+++ b/plugins/coordinator/bin/lib/sentinel-blocks.test.js
@@ -1,0 +1,182 @@
+'use strict';
+/**
+ * sentinel-blocks.test.js — node:test suite for sentinel-blocks.js
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { extractBlock, replaceBlock, insertOrReplaceBlock } = require('./sentinel-blocks.js');
+
+const BEGIN = '<!-- BEGIN alpha -->';
+const END = '<!-- END alpha -->';
+const BEGIN2 = '<!-- BEGIN beta -->';
+const END2 = '<!-- END beta -->';
+
+// ---------------------------------------------------------------------------
+// extractBlock
+// ---------------------------------------------------------------------------
+
+test('extractBlock: returns null when begin marker is absent', () => {
+  const content = 'no markers here\n';
+  assert.strictEqual(extractBlock(content, BEGIN, END), null);
+});
+
+test('extractBlock: returns null when end marker is absent', () => {
+  const content = `before\n${BEGIN}\nsome content\n`;
+  assert.strictEqual(extractBlock(content, BEGIN, END), null);
+});
+
+test('extractBlock: extracts block between markers', () => {
+  const content = `before\n${BEGIN}\nfoo bar\nbaz\n${END}\nafter\n`;
+  const result = extractBlock(content, BEGIN, END);
+  assert.ok(result, 'should not be null');
+  assert.strictEqual(result.block, 'foo bar\nbaz\n');
+  assert.ok(result.before.includes('before'));
+  assert.ok(result.before.includes(BEGIN));
+  assert.ok(result.after.includes(END));
+  assert.ok(result.after.includes('after'));
+});
+
+test('extractBlock: empty block', () => {
+  const content = `${BEGIN}\n${END}\n`;
+  const result = extractBlock(content, BEGIN, END);
+  assert.ok(result);
+  assert.strictEqual(result.block, '');
+});
+
+// ---------------------------------------------------------------------------
+// replaceBlock
+// ---------------------------------------------------------------------------
+
+test('replaceBlock: returns null when markers are missing', () => {
+  assert.strictEqual(replaceBlock('no markers', BEGIN, END, 'new content'), null);
+});
+
+test('replaceBlock: replaces block content, preserves markers', () => {
+  const content = `header\n${BEGIN}\nold content\n${END}\nfooter\n`;
+  const updated = replaceBlock(content, BEGIN, END, 'new content\n');
+  assert.ok(updated.includes(BEGIN));
+  assert.ok(updated.includes(END));
+  assert.ok(updated.includes('new content'));
+  assert.ok(!updated.includes('old content'));
+  assert.ok(updated.includes('header'));
+  assert.ok(updated.includes('footer'));
+});
+
+test('replaceBlock: preserves before and after content unchanged', () => {
+  const before = 'line1\nline2\n';
+  const after = 'line3\nline4\n';
+  const content = before + BEGIN + '\nold\n' + END + '\n' + after;
+  const updated = replaceBlock(content, BEGIN, END, 'replaced\n');
+  assert.ok(updated.startsWith(before));
+  assert.ok(updated.includes(after));
+});
+
+test('replaceBlock: adds trailing newline to newBlockContent if missing', () => {
+  const content = `${BEGIN}\nold\n${END}\n`;
+  const updated = replaceBlock(content, BEGIN, END, 'no-newline');
+  // end marker should be on its own line
+  const lines = updated.split('\n');
+  const endIdx = lines.findIndex(l => l.includes(END));
+  assert.ok(endIdx > 0);
+  // The line before end marker should be the new content
+  assert.strictEqual(lines[endIdx - 1], 'no-newline');
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip
+// ---------------------------------------------------------------------------
+
+test('round-trip: insert, extract, replace, extract again — content equal', () => {
+  const base = 'preamble\n';
+  // Insert block
+  const withBlock = insertOrReplaceBlock(base, BEGIN, END, 'v1 content\n');
+  assert.ok(withBlock.includes(BEGIN));
+  assert.ok(withBlock.includes(END));
+
+  // Extract
+  const ex1 = extractBlock(withBlock, BEGIN, END);
+  assert.strictEqual(ex1.block, 'v1 content\n');
+
+  // Replace
+  const replaced = replaceBlock(withBlock, BEGIN, END, 'v2 content\n');
+  assert.ok(replaced.includes('v2 content'));
+  assert.ok(!replaced.includes('v1 content'));
+
+  // Extract again
+  const ex2 = extractBlock(replaced, BEGIN, END);
+  assert.strictEqual(ex2.block, 'v2 content\n');
+});
+
+// ---------------------------------------------------------------------------
+// insertOrReplaceBlock
+// ---------------------------------------------------------------------------
+
+test('insertOrReplaceBlock: inserts at end when markers missing', () => {
+  const content = 'existing content\n';
+  const result = insertOrReplaceBlock(content, BEGIN, END, 'new block\n');
+  assert.ok(result.startsWith('existing content\n'));
+  assert.ok(result.includes(BEGIN));
+  assert.ok(result.includes('new block'));
+  assert.ok(result.includes(END));
+});
+
+test('insertOrReplaceBlock: inserts at start when insertAt=start', () => {
+  const content = 'existing content\n';
+  const result = insertOrReplaceBlock(content, BEGIN, END, 'new block\n', 'start');
+  assert.ok(result.startsWith(BEGIN));
+  assert.ok(result.includes('existing content'));
+});
+
+test('insertOrReplaceBlock: replaces when markers already exist', () => {
+  const content = `before\n${BEGIN}\nold\n${END}\nafter\n`;
+  const result = insertOrReplaceBlock(content, BEGIN, END, 'new\n');
+  assert.ok(result.includes('new'));
+  assert.ok(!result.includes('old'));
+  assert.ok(result.includes('before'));
+  assert.ok(result.includes('after'));
+});
+
+// ---------------------------------------------------------------------------
+// Multiple independent blocks in one file
+// ---------------------------------------------------------------------------
+
+test('multiple blocks: alpha and beta are independently addressable', () => {
+  const content =
+    `header\n` +
+    `${BEGIN}\nalpha content\n${END}\n` +
+    `middle\n` +
+    `${BEGIN2}\nbeta content\n${END2}\n` +
+    `footer\n`;
+
+  const alpha = extractBlock(content, BEGIN, END);
+  const beta = extractBlock(content, BEGIN2, END2);
+
+  assert.strictEqual(alpha.block, 'alpha content\n');
+  assert.strictEqual(beta.block, 'beta content\n');
+});
+
+test('multiple blocks: replacing alpha does not touch beta', () => {
+  const content =
+    `${BEGIN}\nalpha\n${END}\n` +
+    `${BEGIN2}\nbeta\n${END2}\n`;
+
+  const updated = replaceBlock(content, BEGIN, END, 'new alpha\n');
+  const beta = extractBlock(updated, BEGIN2, END2);
+  assert.strictEqual(beta.block, 'beta\n');
+  assert.ok(!updated.includes('\nalpha\n'));
+  assert.ok(updated.includes('new alpha'));
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+test('replaceBlock is idempotent when new content equals existing content', () => {
+  const content = `${BEGIN}\nsame content\n${END}\n`;
+  const once = replaceBlock(content, BEGIN, END, 'same content\n');
+  const twice = replaceBlock(once, BEGIN, END, 'same content\n');
+  assert.strictEqual(once, twice);
+});

--- a/plugins/coordinator/bin/lint-frontmatter.js
+++ b/plugins/coordinator/bin/lint-frontmatter.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * lint-frontmatter.js — walk every schema'd path glob and validate frontmatter.
+ *
+ * Purpose: hard-fail belt for CI / /validate / /workday-complete. Any tracked record
+ * that fails its schema is surfaced here; exits non-zero if any violations exist.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W1 Hard-fail Gate
+ *
+ * Usage:
+ *   node bin/lint-frontmatter.js [--root <path>] [--schema <name>] [--list-schemas] [--json]
+ *
+ * Options:
+ *   --root <path>      Repo root to walk. Defaults to git rev-parse --show-toplevel, then cwd.
+ *   --schema <name>    Only check one schema by name.
+ *   --list-schemas     Print schema names + globs and exit 0.
+ *   --json             Emit JSON output: {ok, violations: [{file, schema, errors}]}.
+ *
+ * Exit codes:
+ *   0  — all files valid (or --list-schemas)
+ *   1  — one or more violations found
+ *   2  — usage/configuration error
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const {
+  loadSchemas,
+  matchSchemaForPath,
+  parseFrontmatter,
+  validateFrontmatter,
+  validateLessonsFile,
+} = require('./lib/schema.js');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { root: null, schema: null, listSchemas: false, json: false };
+  for (let i = 2; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--root':       args.root = argv[++i]; break;
+      case '--schema':     args.schema = argv[++i]; break;
+      case '--list-schemas': args.listSchemas = true; break;
+      case '--json':       args.json = true; break;
+      default:
+        process.stderr.write(`Unknown argument: ${argv[i]}\n`);
+        process.exit(2);
+    }
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Repo root detection
+// ---------------------------------------------------------------------------
+
+function findRepoRoot(hint) {
+  if (hint) return path.resolve(hint);
+  try {
+    const result = execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    return result.trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File walker — finds all files matching a glob pattern under repoRoot.
+// Only matches at the single-dir depth implied by the glob (not recursive
+// unless the glob contains **).
+// ---------------------------------------------------------------------------
+
+function collectFilesForGlob(repoRoot, glob) {
+  const { matchSchemaForPath: _match, _matchGlob } = require('./lib/schema.js');
+  // Determine the fixed prefix directory from the glob (up to first *, **, or ?)
+  const parts = glob.split('/');
+  const fixedParts = [];
+  for (const p of parts) {
+    if (p.includes('*') || p.includes('?')) break;
+    fixedParts.push(p);
+  }
+
+  const baseDir = path.join(repoRoot, ...fixedParts);
+  const results = [];
+
+  if (!fs.existsSync(baseDir)) return results;
+
+  // Determine how deep to walk: if glob has ** we walk recursively; otherwise one level
+  const hasDoubleStar = glob.includes('**');
+
+  walkDir(baseDir, repoRoot, glob, hasDoubleStar, results);
+  return results;
+}
+
+function walkDir(dir, repoRoot, glob, recursive, results) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const repoRel = path.relative(repoRoot, fullPath).replace(/\\/g, '/');
+
+    if (entry.isDirectory()) {
+      if (recursive) {
+        walkDir(fullPath, repoRoot, glob, recursive, results);
+      }
+    } else if (entry.isFile()) {
+      if (globMatchesPath(glob, repoRel)) {
+        results.push({ fullPath, repoRel });
+      }
+    }
+  }
+}
+
+function globMatchesPath(glob, repoRel) {
+  // Re-use the internal glob logic from schema.js via the exported _matchGlob
+  const schema = require('./lib/schema.js');
+  return schema._matchGlob(glob, repoRel);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv);
+  const repoRoot = findRepoRoot(args.root);
+
+  // Resolve schemas directory relative to this script's location
+  const schemasDir = path.resolve(__dirname, '../schemas');
+
+  if (!fs.existsSync(schemasDir)) {
+    process.stderr.write(`schemas directory not found: ${schemasDir}\n`);
+    process.exit(2);
+  }
+
+  const schemas = loadSchemas(schemasDir);
+
+  // --list-schemas
+  if (args.listSchemas) {
+    const names = Object.keys(schemas).filter(k => k !== '_byGlob');
+    const colW = Math.max(...names.map(n => n.length)) + 2;
+    process.stdout.write(`Schemas (${names.length}) — loaded from ${schemasDir}\n`);
+    for (const name of names) {
+      const s = schemas[name];
+      const glob = s.applies_to || '(no glob)';
+      const mode = s.match_mode ? `[${s.match_mode}]` : '';
+      process.stdout.write(`  ${name.padEnd(colW)}${glob}  ${mode}\n`);
+    }
+    process.exit(0);
+  }
+
+  // Determine which schemas to check
+  const schemasToCheck = args.schema
+    ? schemas[args.schema]
+      ? [{ name: args.schema, schema: schemas[args.schema] }]
+      : (() => { process.stderr.write(`Unknown schema: ${args.schema}\n`); process.exit(2); })()
+    : Object.keys(schemas).filter(k => k !== '_byGlob').map(k => ({ name: k, schema: schemas[k] }));
+
+  const violations = [];
+
+  for (const { name, schema } of schemasToCheck) {
+    const glob = schema.applies_to;
+    if (!glob) continue;
+
+    const isLessonSchema = schema.match_mode === 'inline-tag-per-entry';
+    const files = collectFilesForGlob(repoRoot, glob);
+
+    for (const { fullPath, repoRel } of files) {
+      let content;
+      try {
+        content = fs.readFileSync(fullPath, 'utf8');
+      } catch {
+        violations.push({ file: repoRel, schema: name, errors: [{ field: '(read)', error: 'could not read file', hint: fullPath }] });
+        continue;
+      }
+
+      if (isLessonSchema) {
+        const result = validateLessonsFile(content, schema);
+        if (!result.ok) {
+          violations.push({ file: repoRel, schema: name, errors: result.errors });
+        }
+      } else {
+        const { frontmatter } = parseFrontmatter(content);
+        const result = validateFrontmatter(frontmatter, schema);
+        if (!result.ok) {
+          violations.push({ file: repoRel, schema: name, errors: result.errors });
+        }
+      }
+    }
+  }
+
+  // Output
+  if (args.json) {
+    process.stdout.write(JSON.stringify({ ok: violations.length === 0, violations }, null, 2) + '\n');
+  } else {
+    if (violations.length === 0) {
+      process.stdout.write(`lint-frontmatter: all files valid (root: ${repoRoot})\n`);
+    } else {
+      process.stdout.write(`lint-frontmatter: ${violations.length} violation(s) (root: ${repoRoot})\n\n`);
+      for (const v of violations) {
+        process.stdout.write(`  ${v.file}  [${v.schema}]\n`);
+        for (const e of v.errors) {
+          const loc = e.line ? `:${e.line}` : '';
+          process.stdout.write(`    - ${e.field}${loc}: ${e.error}\n`);
+          if (e.hint) {
+            process.stdout.write(`      hint: ${e.hint}\n`);
+          }
+        }
+      }
+    }
+  }
+
+  process.exit(violations.length > 0 ? 1 : 0);
+}
+
+main();

--- a/plugins/coordinator/bin/lint-frontmatter.sh
+++ b/plugins/coordinator/bin/lint-frontmatter.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# lint-frontmatter.sh — thin wrapper that delegates to the Node CLI.
+# Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W1
+node "$(dirname "$0")/lint-frontmatter.js" "$@"

--- a/plugins/coordinator/bin/orphan-branch-sweep.sh
+++ b/plugins/coordinator/bin/orphan-branch-sweep.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# orphan-branch-sweep.sh — enumerate suspect work/feature branches across the current repo
+#
+# Spec backlink: docs/plans/2026-05-01-orphan-branch-prevention.md § 1.1
+#
+# Purpose: read-only scan of user-owned work/* and feature/* branches. For each
+# qualifying branch, determines whether it has commits that post-date a merged PR
+# (CRITICAL), is an open branch with no PR and a branch-name date ≥2 days old or
+# age_h>36 (WARNING), or is clean (OK). Emits JSON lines to stdout.
+#
+# Negative-spec: this script never mutates branches, refs, or PRs. It is purely
+# diagnostic. It does NOT archive, delete, or rename any branch.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+FORMAT="json"
+SEVERITY_MIN="ok"
+INCLUDE_REMOTE=1
+MAX_AGE_DAYS=30
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --format)       FORMAT="$2";          shift 2 ;;
+    --severity-min) SEVERITY_MIN="$2";    shift 2 ;;
+    --include-remote)  INCLUDE_REMOTE=1;  shift ;;
+    --no-include-remote) INCLUDE_REMOTE=0; shift ;;
+    --max-age-days) MAX_AGE_DAYS="$2";    shift 2 ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: orphan-branch-sweep.sh [OPTIONS]
+
+Options:
+  --format json|text          Output format (default: json)
+  --severity-min ok|warning|critical  Minimum severity to emit (default: ok)
+  --include-remote / --no-include-remote  Include origin/* branches (default: on)
+  --max-age-days N            Ignore branches older than N days (default: 30)
+  --help                      Show this help
+
+Outputs one line per qualifying branch. Exits 0 always (even when gh unavailable).
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Guard: must be inside a git repo
+# ---------------------------------------------------------------------------
+if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Guard: gh must be available for PR state checks
+# ---------------------------------------------------------------------------
+GH_AVAILABLE=0
+if command -v gh &>/dev/null; then
+  GH_AVAILABLE=1
+fi
+
+# ---------------------------------------------------------------------------
+# Severity ordering helper
+# ---------------------------------------------------------------------------
+severity_rank() {
+  case "$1" in
+    OK)       echo 0 ;;
+    WARNING)  echo 1 ;;
+    CRITICAL) echo 2 ;;
+    *)        echo 0 ;;
+  esac
+}
+
+min_rank=$(severity_rank "$(echo "$SEVERITY_MIN" | tr '[:lower:]' '[:upper:]')")
+
+# ---------------------------------------------------------------------------
+# Collect user email for ownership filter
+# ---------------------------------------------------------------------------
+USER_EMAIL=$(git config user.email 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# Collect qualifying branches (local + remote if requested)
+# ---------------------------------------------------------------------------
+declare -A seen_branches
+
+collect_branches() {
+  local raw_list="$1"
+  while IFS= read -r line; do
+    # strip leading whitespace and remote prefix
+    branch=$(echo "$line" | sed 's|^[[:space:]]*||; s|^origin/||; s|^remotes/origin/||')
+    [[ -z "$branch" ]] && continue
+    [[ "$branch" == "HEAD" ]] && continue
+    # only work/* and feature/* branches
+    if [[ "$branch" =~ ^(work|feature)/ ]]; then
+      seen_branches["$branch"]=1
+    fi
+  done <<< "$raw_list"
+}
+
+collect_branches "$(git branch --list 'work/*' 'feature/*' 2>/dev/null)"
+collect_branches "$(git branch --list -r 'origin/work/*' 'origin/feature/*' 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# For each qualifying branch, compute attributes and classify
+# ---------------------------------------------------------------------------
+NOW=$(date +%s)
+MAX_AGE_SECS=$((MAX_AGE_DAYS * 86400))
+
+emit_result() {
+  local branch="$1"
+  local severity="$2"
+  local ahead="$3"
+  local age_h="$4"
+  local pr_json="$5"
+  local orphan_after_merge="$6"
+
+  local rank
+  rank=$(severity_rank "$severity")
+  if [[ $rank -lt $min_rank ]]; then
+    return
+  fi
+
+  if [[ "$FORMAT" == "text" ]]; then
+    if [[ "$severity" == "CRITICAL" ]]; then
+      echo "${severity} ${branch} | ahead=${ahead} age_h=${age_h}h | pr=${pr_json} | orphan_commits=${orphan_after_merge}"
+    elif [[ "$severity" == "WARNING" ]]; then
+      echo "${severity} ${branch} | ahead=${ahead} age_h=${age_h}h | no_pr"
+    else
+      echo "OK ${branch} | ahead=${ahead} age_h=${age_h}h"
+    fi
+  else
+    # JSON line
+    echo "{\"branch\":\"${branch}\",\"ahead\":${ahead},\"age_h\":${age_h},\"pr\":${pr_json},\"orphan_after_merge\":${orphan_after_merge},\"severity\":\"${severity}\"}"
+  fi
+}
+
+for branch in "${!seen_branches[@]}"; do
+  # Skip if tip doesn't exist (stale remote ref that has been deleted locally)
+  if ! git rev-parse "refs/heads/${branch}" &>/dev/null && \
+     ! git rev-parse "refs/remotes/origin/${branch}" &>/dev/null; then
+    continue
+  fi
+
+  # Resolve tip SHA (prefer local, fall back to remote)
+  tip_sha=""
+  if git rev-parse "refs/heads/${branch}" &>/dev/null; then
+    tip_sha=$(git rev-parse "refs/heads/${branch}")
+  else
+    tip_sha=$(git rev-parse "refs/remotes/origin/${branch}")
+  fi
+
+  # Ownership filter: tip author email must match git config user.email
+  if [[ -n "$USER_EMAIL" ]]; then
+    tip_author=$(git log -1 --format="%ae" "$tip_sha" 2>/dev/null || true)
+    if [[ "$tip_author" != "$USER_EMAIL" ]]; then
+      continue
+    fi
+  fi
+
+  # Last-commit age
+  tip_ct=$(git log -1 --format="%ct" "$tip_sha" 2>/dev/null || echo "$NOW")
+  age_secs=$(( NOW - tip_ct ))
+
+  # Skip branches older than max-age-days
+  if [[ $age_secs -gt $MAX_AGE_SECS ]]; then
+    continue
+  fi
+
+  age_h=$(( age_secs / 3600 ))
+
+  # Ahead count against main
+  ahead=0
+  if git rev-parse origin/main &>/dev/null 2>&1; then
+    ahead=$(git rev-list --count "origin/main..${tip_sha}" 2>/dev/null || echo 0)
+  elif git rev-parse main &>/dev/null 2>&1; then
+    ahead=$(git rev-list --count "main..${tip_sha}" 2>/dev/null || echo 0)
+  fi
+
+  # PR state via gh
+  pr_json="null"
+  pr_state=""
+  pr_merged_at=""
+  pr_number=""
+  orphan_after_merge=0
+
+  if [[ $GH_AVAILABLE -eq 1 ]]; then
+    pr_raw=$(gh pr list --head "$branch" --state all --limit 5 \
+      --json number,state,mergedAt,mergeCommit 2>/dev/null || true)
+    if [[ -n "$pr_raw" && "$pr_raw" != "[]" ]]; then
+      # Pick the most recent (last item in array is typically newest)
+      pr_number=$(echo "$pr_raw" | python3 -c "
+import json,sys
+prs=json.load(sys.stdin)
+if prs:
+    p=prs[-1]
+    print(p.get('number',''))
+" 2>/dev/null || true)
+      pr_state=$(echo "$pr_raw" | python3 -c "
+import json,sys
+prs=json.load(sys.stdin)
+if prs:
+    p=prs[-1]
+    print(p.get('state',''))
+" 2>/dev/null || true)
+      pr_merged_at=$(echo "$pr_raw" | python3 -c "
+import json,sys
+prs=json.load(sys.stdin)
+if prs:
+    p=prs[-1]
+    print(p.get('mergedAt') or '')
+" 2>/dev/null || true)
+
+      # Build pr_json fragment
+      pr_json="{\"number\":${pr_number:-0},\"state\":\"${pr_state}\",\"merged_at\":\"${pr_merged_at}\"}"
+
+      # Count commits after merge
+      if [[ "$pr_state" == "MERGED" && -n "$pr_merged_at" ]]; then
+        orphan_after_merge=$(git log "${tip_sha}" \
+          --after="$pr_merged_at" \
+          --format="%H" 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+      fi
+    fi
+  fi
+
+  # ---------------------------------------------------------------------------
+  # Classify severity
+  # ---------------------------------------------------------------------------
+  severity="OK"
+
+  if [[ "$pr_state" == "MERGED" && $orphan_after_merge -gt 0 ]]; then
+    severity="CRITICAL"
+  elif [[ "$pr_state" != "MERGED" && $ahead -gt 0 ]]; then
+    # Extract date from branch name if present (work/machine/YYYY-MM-DD pattern)
+    branch_date=""
+    if [[ "$branch" =~ ([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+      branch_date="${BASH_REMATCH[1]}"
+    fi
+
+    branch_age_days=0
+    if [[ -n "$branch_date" ]]; then
+      branch_ts=$(date -d "$branch_date" +%s 2>/dev/null || \
+                  python3 -c "import datetime; print(int(datetime.datetime.strptime('$branch_date','%Y-%m-%d').timestamp()))" 2>/dev/null || \
+                  echo "0")
+      if [[ $branch_ts -gt 0 ]]; then
+        branch_age_days=$(( (NOW - branch_ts) / 86400 ))
+      fi
+    fi
+
+    if [[ $branch_age_days -ge 2 || $age_h -gt 36 ]]; then
+      severity="WARNING"
+    fi
+  fi
+
+  emit_result "$branch" "$severity" "$ahead" "$age_h" "${pr_json:-null}" "$orphan_after_merge"
+
+done

--- a/plugins/coordinator/bin/query-records.js
+++ b/plugins/coordinator/bin/query-records.js
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * query-records.js — Frontmatter-indexed query CLI for coordinator tracked records.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2 (Query Tool)
+ *
+ * Usage:
+ *   query-records --type <handoff|decision|plan|review|worker-run|lesson>
+ *                 [--where "<expr>"]
+ *                 [--sort "<field>|-<field>"]
+ *                 [--limit N]
+ *                 [--since "Nd"|"Nw"|"Nm"|"YYYY-MM-DD"]
+ *                 [--root <path>]
+ *                 [--format markdown-list|json|paths]
+ *
+ * --where expression syntax (single-level AND conjunctions only, no OR, no parens):
+ *   field=value, field!=value, field in (a,b,c), field<value, field>value,
+ *   field<=value, field>=value
+ *   Expressions may be joined with " AND " or " and ".
+ *
+ * --since 14d is sugar for created>=<today minus 14d>.
+ *   Accepts: Nd (days), Nw (weeks), Nm (months≈30d), or YYYY-MM-DD.
+ *
+ * Lesson type is special: parses tasks/lessons.md entries.
+ *   --where "tier=universal" matches entries tagged [universal].
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { loadSchemas, parseFrontmatter } = require('./lib/schema.js');
+
+// ---------------------------------------------------------------------------
+// Schema-to-glob mapping (must match schema applies_to)
+// ---------------------------------------------------------------------------
+const TYPE_TO_GLOB = {
+  handoff:    'tasks/handoffs/*.md',
+  decision:   'docs/decisions/*.md',
+  plan:       'docs/plans/*.md',
+  review:     'tasks/reviews/*.md',
+  'worker-run': 'tasks/worker-runs/*.md',
+  lesson:     'tasks/lessons.md', // special
+};
+
+// Markdown-list format columns per type (field name → label)
+const TYPE_DISPLAY = {
+  handoff:    (p, fm) => `- [${fm.title || path.basename(p)}](${p}) — ${fm.status || 'unknown'}`,
+  decision:   (p, fm) => `- [${fm.title || path.basename(p)}](${p}) — ${fm.status || 'unknown'}`,
+  plan:       (p, fm) => `- [${fm.title || path.basename(p)}](${p}) — ${fm.status || 'unknown'}`,
+  review:     (p, fm) => `- [${fm.title || path.basename(p)}](${p}) — reviewer: ${fm.reviewer || '?'}, findings: ${fm.findings_count ?? '?'}`,
+  'worker-run': (p, fm) => `- [${fm.title || path.basename(p)}](${p}) — worker: ${fm.worker || '?'}, findings: ${fm.findings_count ?? '?'}`,
+  lesson:     (p, fm) => `- **${fm.title || p}** [${fm.tier || 'untagged'}]`,
+};
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = {
+    type: null,
+    where: null,
+    sort: null,
+    limit: 50,
+    since: null,
+    root: null,
+    format: 'markdown-list',
+  };
+
+  // Review: patrik R2 finding 4 — normalize --key=value form to --key value before dispatch.
+  // Operators (hand invocation) naturally reach for --sort=-created; the callout consumer
+  // builds space-separated args, so production paths were unaffected. Both forms now work.
+  const normalizedArgs = [];
+  for (const a of args) {
+    if (a.startsWith('--') && a.includes('=')) {
+      const eqIdx = a.indexOf('=');
+      normalizedArgs.push(a.slice(0, eqIdx), a.slice(eqIdx + 1));
+    } else {
+      normalizedArgs.push(a);
+    }
+  }
+
+  for (let i = 0; i < normalizedArgs.length; i++) {
+    const a = normalizedArgs[i];
+    if (a === '--type')   { opts.type   = normalizedArgs[++i]; }
+    else if (a === '--where')  { opts.where  = normalizedArgs[++i]; }
+    else if (a === '--sort')   { opts.sort   = normalizedArgs[++i]; }
+    else if (a === '--limit')  { opts.limit  = parseInt(normalizedArgs[++i], 10); }
+    else if (a === '--since')  { opts.since  = normalizedArgs[++i]; }
+    else if (a === '--root')   { opts.root   = normalizedArgs[++i]; }
+    else if (a === '--format') { opts.format = normalizedArgs[++i]; }
+    else {
+      process.stderr.write(`Unknown argument: ${a}\n`);
+      process.exit(1);
+    }
+  }
+
+  if (!opts.type) {
+    process.stderr.write('--type is required\n');
+    process.exit(1);
+  }
+  if (!TYPE_TO_GLOB[opts.type]) {
+    process.stderr.write(`Unknown type: ${opts.type}. Valid: ${Object.keys(TYPE_TO_GLOB).join(', ')}\n`);
+    process.exit(1);
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Root detection
+// ---------------------------------------------------------------------------
+function detectRoot(specified) {
+  if (specified) return path.resolve(specified);
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: ['pipe','pipe','pipe'] }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Since helper
+// ---------------------------------------------------------------------------
+function parseSince(since) {
+  if (!since) return null;
+  const isoRe = /^\d{4}-\d{2}-\d{2}$/;
+  if (isoRe.test(since)) return since;
+
+  const relRe = /^(\d+)(d|w|m)$/;
+  const m = relRe.exec(since);
+  if (!m) {
+    process.stderr.write(`Invalid --since value: ${since}\n`);
+    process.exit(1);
+  }
+  const n = parseInt(m[1], 10);
+  const unit = m[2];
+  const days = unit === 'd' ? n : unit === 'w' ? n * 7 : n * 30;
+  const dt = new Date();
+  dt.setDate(dt.getDate() - days);
+  return dt.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Where expression parser
+// ---------------------------------------------------------------------------
+const OPS = ['!=', '<=', '>=', '<', '>', '=', ' in '];
+
+function parseWhereExpr(expr) {
+  // Split on " AND " or " and " (case-insensitive), outside parens
+  const clauses = expr.split(/\s+and\s+/i).map(s => s.trim()).filter(Boolean);
+  return clauses.map(parseClause);
+}
+
+function parseClause(clause) {
+  // Check "in" operator first (field in (a,b,c))
+  const inRe = /^(\w+)\s+in\s*\(([^)]*)\)$/i;
+  const inM = inRe.exec(clause);
+  if (inM) {
+    const values = inM[2].split(',').map(s => s.trim());
+    return { field: inM[1], op: 'in', values };
+  }
+
+  for (const op of ['!=', '<=', '>=', '<', '>', '=']) {
+    const idx = clause.indexOf(op);
+    if (idx !== -1) {
+      const field = clause.slice(0, idx).trim();
+      const value = clause.slice(idx + op.length).trim();
+      return { field, op, value };
+    }
+  }
+
+  process.stderr.write(`Cannot parse where clause: "${clause}"\n`);
+  process.exit(1);
+}
+
+function compareValues(a, b) {
+  // Try numeric comparison first
+  const na = Number(a), nb = Number(b);
+  if (!isNaN(na) && !isNaN(nb)) return na - nb;
+  // Fall back to string comparison (handles ISO dates lexicographically)
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function matchesClause(fm, clause) {
+  const rawVal = fm[clause.field];
+  const fmVal = rawVal === undefined || rawVal === null ? '' : String(rawVal);
+
+  switch (clause.op) {
+    case '=':   return fmVal === clause.value;
+    case '!=':  return fmVal !== clause.value;
+    case 'in':  return clause.values.includes(fmVal);
+    case '<':   return compareValues(fmVal, clause.value) < 0;
+    case '>':   return compareValues(fmVal, clause.value) > 0;
+    case '<=':  return compareValues(fmVal, clause.value) <= 0;
+    case '>=':  return compareValues(fmVal, clause.value) >= 0;
+    default:    return false;
+  }
+}
+
+function matchesWhere(fm, clauses) {
+  return clauses.every(c => matchesClause(fm, c));
+}
+
+// ---------------------------------------------------------------------------
+// Glob file walker (no external deps)
+// ---------------------------------------------------------------------------
+function walkGlob(root, globPattern) {
+  // Convert glob to a simple two-part: prefix dir + filename pattern
+  // Our globs are always "some/path/*.md" — handle that form.
+  const normalised = globPattern.replace(/\\/g, '/');
+  const parts = normalised.split('/');
+  const filePattern = parts[parts.length - 1];
+  const dirParts = parts.slice(0, -1);
+
+  const dir = path.join(root, ...dirParts);
+  if (!fs.existsSync(dir)) return [];
+
+  const stat = fs.statSync(dir);
+  if (!stat.isDirectory()) {
+    // It's a file path directly (e.g., tasks/lessons.md)
+    return fs.existsSync(path.join(root, normalised)) ? [path.join(root, normalised)] : [];
+  }
+
+  const fileRe = filePatternToRegex(filePattern);
+  return fs.readdirSync(dir)
+    .filter(f => fileRe.test(f))
+    .map(f => path.join(dir, f));
+}
+
+function filePatternToRegex(pattern) {
+  let re = '';
+  for (const c of pattern) {
+    if (c === '*') re += '[^/]*';
+    else if (c === '?') re += '[^/]';
+    else if ('.+^${}()|[]\\'.includes(c)) re += '\\' + c;
+    else re += c;
+  }
+  return new RegExp('^' + re + '$');
+}
+
+// ---------------------------------------------------------------------------
+// Lesson parser
+// ---------------------------------------------------------------------------
+/**
+ * Parse tasks/lessons.md into a list of record objects.
+ * Each entry is a bold-title line followed by body text until the next entry.
+ * Returns [{title, tier, body, path}].
+ */
+function parseLessonsFile(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+  const records = [];
+
+  const entryRe = /^\s*[-*]?\s*\*\*([^*]+)\*\*/;
+  const tagRe = /\[([^\]]+)\]/g;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = entryRe.exec(line);
+    if (!m) continue;
+
+    const rawTitle = m[1].trim();
+
+    // Extract tier tag from the line
+    const tags = [];
+    let tm;
+    tagRe.lastIndex = 0;
+    while ((tm = tagRe.exec(line)) !== null) {
+      tags.push(tm[1]);
+    }
+    // Remove tags from title
+    const title = rawTitle;
+    const tier = tags.length > 0 ? tags[0] : null;
+
+    // Slug for fragment links
+    const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+    records.push({
+      title,
+      tier,
+      path: filePath + '#' + slug,
+      frontmatter: { title, tier: tier || 'untagged', created: null },
+    });
+  }
+
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Main query function (exported for use by refresh-queries)
+// ---------------------------------------------------------------------------
+function queryRecords(opts, root) {
+  const glob = TYPE_TO_GLOB[opts.type];
+
+  let records;
+
+  if (opts.type === 'lesson') {
+    const lessonsPath = path.join(root, 'tasks', 'lessons.md');
+    const parsed = parseLessonsFile(lessonsPath);
+    records = parsed.map(r => ({ path: r.path, frontmatter: r.frontmatter }));
+  } else {
+    const files = walkGlob(root, glob);
+    records = [];
+    for (const file of files) {
+      let content;
+      try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
+      const { frontmatter } = parseFrontmatter(content);
+      if (!frontmatter) continue;
+      const relPath = path.relative(root, file).replace(/\\/g, '/');
+      records.push({ path: relPath, frontmatter });
+    }
+  }
+
+  // Apply --since as created>= filter
+  const since = parseSince(opts.since);
+  if (since) {
+    records = records.filter(r => {
+      const c = r.frontmatter.created;
+      if (!c) return false;
+      return String(c) >= since;
+    });
+  }
+
+  // Apply --where filter
+  let whereClauses = [];
+  if (opts.where) {
+    whereClauses = parseWhereExpr(opts.where);
+    records = records.filter(r => matchesWhere(r.frontmatter, whereClauses));
+  }
+
+  // Apply --sort
+  if (opts.sort) {
+    const desc = opts.sort.startsWith('-');
+    const field = desc ? opts.sort.slice(1) : opts.sort;
+    records.sort((a, b) => {
+      const av = a.frontmatter[field] ?? '';
+      const bv = b.frontmatter[field] ?? '';
+      const cmp = compareValues(String(av), String(bv));
+      return desc ? -cmp : cmp;
+    });
+  }
+
+  // Apply --limit
+  if (opts.limit && opts.limit > 0) {
+    records = records.slice(0, opts.limit);
+  }
+
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+function formatRecords(records, opts) {
+  switch (opts.format) {
+    case 'json':
+      return JSON.stringify(records, null, 2);
+    case 'paths':
+      return records.map(r => r.path).join('\n');
+    case 'markdown-list':
+    default: {
+      const displayFn = TYPE_DISPLAY[opts.type] || ((p, fm) => `- [${fm.title || p}](${p})`);
+      return records.map(r => displayFn(r.path, r.frontmatter)).join('\n');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const opts = parseArgs(process.argv);
+  const root = detectRoot(opts.root);
+
+  const records = queryRecords(opts, root);
+  const output = formatRecords(records, opts);
+
+  if (output) {
+    process.stdout.write(output + '\n');
+  }
+}
+
+module.exports = { queryRecords, formatRecords, parseSince, parseWhereExpr };

--- a/plugins/coordinator/bin/query-records.sh
+++ b/plugins/coordinator/bin/query-records.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# query-records.sh — Thin shell wrapper for query-records.js
+#
+# Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2
+#
+# Usage: query-records.sh --type <type> [options...]
+# All arguments are forwarded verbatim to the Node script.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "$SCRIPT_DIR/query-records.js" "$@"

--- a/plugins/coordinator/bin/refresh-queries.js
+++ b/plugins/coordinator/bin/refresh-queries.js
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * refresh-queries.js — Expand query callouts in markdown files in-place.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2 (Refresh Helper)
+ *
+ * Callout format:
+ *   <!-- BEGIN query: <type> [where=...] [sort=...] [limit=N] [since=...] -->
+ *   ... (current expansion, will be overwritten) ...
+ *   <!-- END query -->
+ *
+ * The spec line is the source of truth. The block between the markers is regenerated.
+ * Running twice with no data changes produces no diff (idempotent).
+ *
+ * Usage:
+ *   refresh-queries [--root <path>] [--check] [--files <glob>]
+ *
+ *   --check  Don't write files; exit 1 if any file would change. For CI.
+ *   --files  Glob of markdown files to scan (default: **‌/*.md, excluding node_modules/.git/archive/).
+ *   --root   Repo root (default: git rev-parse --show-toplevel, fallback cwd).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { extractBlock, replaceBlock } = require('./lib/sentinel-blocks.js');
+const { queryRecords, formatRecords, parseSince } = require('./query-records.js');
+
+const BEGIN_PREFIX = '<!-- BEGIN query:';
+const END_MARKER = '<!-- END query -->';
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = { root: null, check: false, files: '**/*.md' };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--root')  { opts.root  = args[++i]; }
+    else if (a === '--check') { opts.check = true; }
+    else if (a === '--files') { opts.files = args[++i]; }
+    else {
+      process.stderr.write(`Unknown argument: ${a}\n`);
+      process.exit(1);
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Root detection
+// ---------------------------------------------------------------------------
+function detectRoot(specified) {
+  if (specified) return path.resolve(specified);
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: ['pipe','pipe','pipe'] }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query spec parser — parses "<!-- BEGIN query: type [key=value ...] -->"
+// Returns opts object compatible with queryRecords / formatRecords.
+// ---------------------------------------------------------------------------
+function parseQuerySpec(beginMarker) {
+  // Strip "<!-- BEGIN query:" prefix and " -->" suffix
+  const inner = beginMarker
+    .replace(/^<!--\s*BEGIN query:\s*/, '')
+    .replace(/\s*-->$/, '')
+    .trim();
+
+  const tokens = inner.split(/\s+/);
+  const type = tokens[0];
+  if (!type) throw new Error(`Empty query spec in: ${beginMarker}`);
+
+  const opts = { type, where: null, sort: null, limit: 50, since: null, format: 'markdown-list' };
+
+  for (let i = 1; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t.startsWith('where=')) {
+      opts.where = t.slice('where='.length);
+    } else if (t.startsWith('sort=')) {
+      opts.sort = t.slice('sort='.length);
+    } else if (t.startsWith('limit=')) {
+      opts.limit = parseInt(t.slice('limit='.length), 10);
+    } else if (t.startsWith('since=')) {
+      opts.since = t.slice('since='.length);
+    } else if (t.startsWith('format=')) {
+      opts.format = t.slice('format='.length);
+    }
+    // Unknown tokens are ignored gracefully — forward compat
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Walk markdown files (simple recursive glob for **/*.md, no external deps)
+// ---------------------------------------------------------------------------
+const EXCLUDED_DIRS = new Set(['node_modules', '.git', 'archive']);
+
+function walkMd(dir, results = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return results; }
+
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (!EXCLUDED_DIRS.has(e.name)) {
+        walkMd(path.join(dir, e.name), results);
+      }
+    } else if (e.isFile() && e.name.endsWith('.md')) {
+      results.push(path.join(dir, e.name));
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Fenced-code-block detector — returns a Set of line numbers (0-based) that
+// are inside ``` or ~~~ fenced code blocks. Used to skip markers in examples.
+// ---------------------------------------------------------------------------
+function buildCodeBlockLineSet(content) {
+  const lines = content.split('\n');
+  const inCode = new Set();
+  let inside = false;
+  let fence = null;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    if (!inside) {
+      if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+        inside = true;
+        fence = trimmed.slice(0, 3);
+      }
+    } else {
+      inCode.add(i);
+      if (trimmed.startsWith(fence)) {
+        inside = false;
+        fence = null;
+      }
+    }
+  }
+  return inCode;
+}
+
+/**
+ * Given a byte offset into content, return its 0-based line number.
+ * Cached via a simple walk — fine for files of our size.
+ */
+function lineOfOffset(content, offset) {
+  let line = 0;
+  for (let i = 0; i < offset; i++) {
+    if (content[i] === '\n') line++;
+  }
+  return line;
+}
+
+// ---------------------------------------------------------------------------
+// Process a single file — find all query callouts, expand them.
+// Returns { changed: bool, changedCount: number, errorCount: number }.
+// ---------------------------------------------------------------------------
+function processFile(filePath, root, checkMode) {
+  let content;
+  try { content = fs.readFileSync(filePath, 'utf8'); } catch { return { changed: false, changedCount: 0, errorCount: 0 }; }
+
+  if (!content.includes(BEGIN_PREFIX)) {
+    return { changed: false, changedCount: 0, errorCount: 0 };
+  }
+
+  let working = content;
+  let changedCount = 0;
+  let errorCount = 0;
+  let offset = 0;
+
+  // Find all BEGIN query: markers and process each
+  while (true) {
+    const idx = working.indexOf(BEGIN_PREFIX, offset);
+    if (idx === -1) break;
+
+    // Skip markers inside fenced code blocks or inline backtick spans
+    // (they are documentation examples, not live callouts)
+    const codeLines = buildCodeBlockLineSet(working);
+    const markerLine = lineOfOffset(working, idx);
+    if (codeLines.has(markerLine)) {
+      offset = idx + BEGIN_PREFIX.length;
+      continue;
+    }
+
+    // Check if this marker is inside inline backtick code on its line.
+    // Find start of this line, count backticks before the marker position.
+    let lineStartIdx = idx;
+    while (lineStartIdx > 0 && working[lineStartIdx - 1] !== '\n') lineStartIdx--;
+    const textBeforeMarker = working.slice(lineStartIdx, idx);
+    const backticksBefore = (textBeforeMarker.match(/`/g) || []).length;
+    if (backticksBefore % 2 === 1) {
+      // Odd count means we're inside an inline code span
+      offset = idx + BEGIN_PREFIX.length;
+      continue;
+    }
+
+    // Find the end of the begin marker line
+    const lineEnd = working.indexOf('\n', idx);
+    if (lineEnd === -1) break;
+    const beginMarker = working.slice(idx, lineEnd).trim();
+
+    // Build the full marker including any leading/trailing whitespace on the line
+    // We need to find the exact begin marker as it appears for sentinel-blocks
+    const lineStart = (() => {
+      let s = idx;
+      while (s > 0 && working[s - 1] !== '\n') s--;
+      return s;
+    })();
+    const beginMarkerFull = working.slice(lineStart, lineEnd + 1).replace(/\r?\n$/, '');
+
+    let queryOpts;
+    try {
+      queryOpts = parseQuerySpec(beginMarker);
+    } catch (e) {
+      process.stderr.write(`  Warning: ${filePath}: ${e.message}\n`);
+      errorCount++;
+      offset = lineEnd + 1;
+      continue;
+    }
+
+    // Check END marker exists
+    if (!working.includes(END_MARKER, lineEnd)) {
+      process.stderr.write(`  Warning: ${filePath}: BEGIN query without END query\n`);
+      errorCount++;
+      offset = lineEnd + 1;
+      continue;
+    }
+
+    // Run the query
+    let records;
+    try {
+      records = queryRecords(queryOpts, root);
+    } catch (e) {
+      process.stderr.write(`  Warning: ${filePath}: query failed: ${e.message}\n`);
+      errorCount++;
+      offset = lineEnd + 1;
+      continue;
+    }
+
+    const expansion = formatRecords(records, queryOpts);
+
+    // Replace block using exact begin marker (the spec line content)
+    const updated = replaceBlock(working, beginMarker, END_MARKER, expansion ? expansion + '\n' : '');
+    if (updated === null) {
+      process.stderr.write(`  Warning: ${filePath}: sentinel-blocks replaceBlock returned null\n`);
+      errorCount++;
+      offset = lineEnd + 1;
+      continue;
+    }
+
+    if (updated !== working) {
+      changedCount++;
+    }
+    working = updated;
+    // Reset offset to after the begin marker to handle multiple callouts
+    offset = working.indexOf(beginMarker) + beginMarker.length;
+    if (offset <= 0) break;
+  }
+
+  if (changedCount > 0) {
+    if (!checkMode) {
+      fs.writeFileSync(filePath, working, 'utf8');
+    }
+    return { changed: true, changedCount, errorCount };
+  }
+  return { changed: false, changedCount: 0, errorCount };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+  const opts = parseArgs(process.argv);
+  const root = detectRoot(opts.root);
+
+  const files = walkMd(root);
+  let totalChanged = 0;
+  let totalErrors = 0;
+
+  for (const file of files) {
+    const { changed, changedCount, errorCount } = processFile(file, root, opts.check);
+    if (changed) {
+      const rel = path.relative(root, file);
+      process.stdout.write(`${opts.check ? '[would change]' : '[updated]'} ${rel} (${changedCount} callout(s))\n`);
+      totalChanged++;
+    }
+    totalErrors += errorCount;
+  }
+
+  if (totalChanged === 0 && totalErrors === 0) {
+    process.stdout.write('All query callouts are up to date.\n');
+  }
+
+  if (opts.check && totalChanged > 0) {
+    process.stderr.write(`\n${totalChanged} file(s) have out-of-sync query callouts. Run refresh-queries.sh to fix.\n`);
+    process.exit(1);
+  }
+
+  if (totalErrors > 0) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { processFile, parseQuerySpec };

--- a/plugins/coordinator/bin/refresh-queries.sh
+++ b/plugins/coordinator/bin/refresh-queries.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# refresh-queries.sh — Thin shell wrapper for refresh-queries.js
+#
+# Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W2
+#
+# Usage: refresh-queries.sh [--root <path>] [--check] [--files <glob>]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "$SCRIPT_DIR/refresh-queries.js" "$@"

--- a/plugins/coordinator/bin/sync-main.sh
+++ b/plugins/coordinator/bin/sync-main.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# sync-main.sh — ensure local origin/main ref (and local main when safe) are
+#                at the latest pushed state before any branch creation.
+#
+# Spec backlink: docs/plans/2026-05-01-orphan-branch-prevention.md § 1.1.5
+#
+# Purpose: the branch-creation invariant. Every branch-creation site in the
+# coordinator pipeline calls this before `git checkout -b`. After this script
+# succeeds, local main == origin/main regardless of which branch the working
+# tree is on — callers can trust `git checkout -b new-branch main`.
+#
+# Negative-spec: does NOT create branches, does NOT push, does NOT merge
+# feature/work branches, does NOT touch anything other than the main ref.
+
+set -euo pipefail
+
+QUIET=0
+STRICT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quiet)  QUIET=1;  shift ;;
+    --strict) STRICT=1; shift ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: sync-main.sh [OPTIONS]
+
+Ensures local main == origin/main before any branch creation.
+
+Options:
+  --quiet     Suppress normal informational output
+  --strict    Treat >50-commits-behind warning as a hard error (exit 1)
+  --help      Show this help
+
+Exits 0 on success, non-zero when divergence cannot be resolved silently.
+Skips silently when not inside a git repository.
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Guard: must be inside a git repo
+# ---------------------------------------------------------------------------
+if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+  exit 0
+fi
+
+info() {
+  [[ $QUIET -eq 1 ]] && return
+  echo "[sync-main] $*" >&2
+}
+
+warn() {
+  echo "[sync-main] WARNING: $*" >&2
+}
+
+die() {
+  echo "[sync-main] ERROR: $*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Verify origin/main is reachable
+# ---------------------------------------------------------------------------
+if ! git ls-remote --exit-code origin main &>/dev/null; then
+  # No remote named origin or no main branch there — silently skip
+  info "origin/main not reachable — skipping sync (offline or non-standard remote)"
+  exit 0
+fi
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+  # On main: fetch + ff-only pull
+  info "On main — fetching and fast-forwarding..."
+  git fetch origin main 2>/dev/null
+
+  # Check whether local main is ahead of origin/main
+  LOCAL_AHEAD=$(git rev-list --count "origin/main..HEAD" 2>/dev/null || echo 0)
+  if [[ $LOCAL_AHEAD -gt 0 ]]; then
+    die "Local main is ${LOCAL_AHEAD} commit(s) ahead of origin/main. This should never happen — investigate before branching. (Did a previous operation commit directly to main?)"
+  fi
+
+  git pull --ff-only origin main 2>/dev/null || \
+    die "Fast-forward pull failed. Local main has diverged from origin/main in a way sync-main.sh cannot resolve automatically."
+
+  info "main is now at $(git rev-parse --short HEAD)"
+
+else
+  # On a non-main branch: update the local main ref via refspec without checkout
+  info "On branch '${CURRENT_BRANCH}' — updating local main ref from origin..."
+  git fetch origin "main:main" 2>/dev/null || {
+    # fetch with refspec fails when local main is ahead of origin/main
+    git fetch origin main 2>/dev/null
+    # Check if local main is ahead
+    LOCAL_AHEAD=$(git rev-list --count "refs/remotes/origin/main..refs/heads/main" 2>/dev/null || echo 0)
+    if [[ $LOCAL_AHEAD -gt 0 ]]; then
+      die "Local main is ${LOCAL_AHEAD} commit(s) ahead of origin/main. Investigate before branching."
+    fi
+    # Otherwise just let the remote ref update
+    git fetch origin main 2>/dev/null
+  }
+  info "Local main ref is now at $(git rev-parse --short main 2>/dev/null || git rev-parse --short origin/main)"
+fi
+
+# ---------------------------------------------------------------------------
+# Warn if current branch is >50 commits behind updated main
+# ---------------------------------------------------------------------------
+if [[ -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "main" ]]; then
+  BEHIND=$(git rev-list --count "HEAD..main" 2>/dev/null || echo 0)
+  if [[ $BEHIND -gt 50 ]]; then
+    if [[ $STRICT -eq 1 ]]; then
+      die "Current branch is ${BEHIND} commits behind main. Resolve divergence before proceeding (--strict mode)."
+    else
+      warn "Current branch '${CURRENT_BRANCH}' is ${BEHIND} commits behind main. Consider rebasing or merging main before creating a new branch from here."
+    fi
+  fi
+fi
+
+info "sync-main complete."
+exit 0

--- a/plugins/coordinator/bin/tests/test-coordinator-safe-commit.sh
+++ b/plugins/coordinator/bin/tests/test-coordinator-safe-commit.sh
@@ -354,13 +354,20 @@ test_blanket_invocation_logged_proper() {
 }
 
 # T12: --scope-from parses valid frontmatter, stages within scope
+# Note: scoped-file.txt is pre-committed (tracked) so the W2.1 membership gate
+# passes it unconditionally — tracked files are admitted without a touched.txt check.
+# out-of-scope.txt is not in the handoff scope so it must not appear in the commit.
 test_scope_from_valid_frontmatter() {
   setup_repo
   local my_sid="session-mine-$$"
   make_session "$my_sid" "$$"
 
-  # Create files
+  # Pre-commit scoped-file.txt so it is tracked (W2.1 gate: tracked files pass unconditionally).
   echo "scoped content" > scoped-file.txt
+  git add scoped-file.txt && git commit -q -m "track scoped-file.txt"
+  # Modify it so it shows as dirty (will be staged by scope-from).
+  echo "scoped content updated" > scoped-file.txt
+
   echo "out of scope" > out-of-scope.txt
 
   # Create handoff file with YAML frontmatter
@@ -529,13 +536,21 @@ HANDOFF
 }
 
 # T19: Scope-from frontmatter union with touched.txt (resuming session touches additional files)
+# scoped-file.txt is in the handoff scope but NOT in touched.txt — it is pre-committed
+# (tracked) so the W2.1 gate admits it unconditionally.
+# extra-touched.txt is NOT in the handoff scope but IS in touched.txt — it enters via
+# the union path and passes the membership gate as a touched untracked file.
 test_scope_from_union_with_touched() {
   setup_repo
   local my_sid="session-mine-$$"
   make_session "$my_sid" "$$" "extra-touched.txt"  # session touched this beyond handoff scope
 
+  # Pre-commit scoped-file.txt so it is tracked (passes W2.1 gate unconditionally).
   echo "scoped" > scoped-file.txt
-  echo "extra" > extra-touched.txt
+  git add scoped-file.txt && git commit -q -m "track scoped-file.txt"
+  echo "scoped updated" > scoped-file.txt   # make dirty
+
+  echo "extra" > extra-touched.txt   # untracked, in my touched.txt — passes W2.1 via union
 
   mkdir -p tasks/handoffs
   cat > tasks/handoffs/handoff.md <<'HANDOFF'
@@ -564,12 +579,18 @@ HANDOFF
 # Regression for the "touch-tracker not firing" bug observed across 4+ sessions:
 # CRLF-encoded handoffs produced "no scope: field found" because "$line" == "---"
 # silently failed to match "---\r". Parser now strips trailing CR.
+# Note: scoped-file.txt is pre-committed (tracked) so the W2.1 membership gate
+# admits it unconditionally — this test focuses on CRLF parsing, not membership.
 test_scope_from_crlf_handoff() {
   setup_repo
   local my_sid="session-mine-$$"
   make_session "$my_sid" "$$"
 
+  # Pre-commit scoped-file.txt so it is tracked (passes W2.1 gate unconditionally).
   echo "scoped content" > scoped-file.txt
+  git add scoped-file.txt && git commit -q -m "track scoped-file.txt"
+  echo "scoped content updated" > scoped-file.txt   # make dirty
+
   echo "out of scope" > out-of-scope.txt
 
   mkdir -p tasks/handoffs
@@ -624,6 +645,746 @@ HANDOFF
 }
 
 # ---------------------------------------------------------------------------
+# W2.0 tests — cross-session subtraction in --scope-from mode
+# ---------------------------------------------------------------------------
+
+# T22 (W2.0): --scope-from subtracts a file claimed by another session
+# Scenario: handoff scope = mine.md (tracked, modified), session B claims other.md (also
+# untracked in this repo). other.md must NOT be staged even though it is dirty and untracked.
+# Spec backlink: plan W2.0 — do_scope_from cross-session subtraction.
+test_scope_from_subtracts_other_session_file() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  # Session A: I own mine.md
+  make_session "$my_sid" "$$" "mine.md"
+  # Session B: they own other.md
+  make_session "$other_sid" "99999" "other.md"
+
+  # Create and track mine.md
+  echo "my content" > mine.md
+  git add mine.md && git commit -q -m "track mine.md"
+  # Modify mine.md so it shows as dirty
+  echo "my updated content" > mine.md
+
+  # Create other.md as untracked (dirty, claimed by session B)
+  echo "other content" > other.md
+
+  # Create handoff that only scopes mine.md
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w20-test
+scope:
+  - mine.md
+---
+# W2.0 handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W2.0 subtraction" 2>&1) || rc=$?
+
+  local commit_files
+  commit_files=$(git show --name-only HEAD --format="" | grep -v "^$" || true)
+
+  teardown_repo
+  [[ $rc -eq 0 ]] \
+    && assert_contains "T22-mine-committed" "mine.md" "$commit_files" \
+    && assert_not_contains "T22-other-excluded" "other.md" "$commit_files"
+}
+
+# ---------------------------------------------------------------------------
+# W2.2 tests — empty-post-exclusion fail-closed with stale-claim diagnostic
+# ---------------------------------------------------------------------------
+
+# T23 (W2.2): When handoff scope names a tracked file claimed entirely by another
+# session, abort with a stale-claim diagnostic (not a generic "no scope" error).
+# Scenario: handoff scope = contested.txt (TRACKED — pre-committed so W2.1 gate
+# admits it). Session B claims contested.txt. Session A has no claims. After the
+# W2.1-admitting tracked-file expansion, cross-session subtraction excludes it:
+# my_scope = [] and other_excluded = [contested.txt] → W2.2 stale-claim fires.
+# Spec backlink: plan W2.2 — fail-closed on empty post-exclusion scope.
+test_scope_from_stale_claim_fail_closed() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  make_session "$my_sid" "$$"                           # A has no claims
+  make_session "$other_sid" "99999" "contested.txt"     # B claims it
+
+  # Pre-commit contested.txt so it is tracked (W2.1 gate: tracked files pass unconditionally).
+  echo "contested content" > contested.txt
+  git add contested.txt && git commit -q -m "track contested.txt"
+  echo "contested updated" > contested.txt   # make dirty
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w22-fail-closed-test
+scope:
+  - contested.txt
+---
+# W2.2 fail-closed handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W2.2 fail-closed" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T23-stale-claim" "claimed by other session" "$out"
+}
+
+# T24 (W2.2): Stale-claim diagnostic must name the specific session that claimed entries.
+# Files are pre-committed (tracked) so the W2.1 gate admits them; the cross-session
+# subtraction step then fires the stale-claim diagnostic.
+# Spec backlink: plan W2.2 — diagnostic naming the other session(s).
+test_scope_from_stale_claim_diagnostic_names_other_session() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  make_session "$my_sid" "$$"                  # A has no claims
+  make_session "$other_sid" "99999" "mine.md"  # B claims mine.md
+
+  # Pre-commit mine.md so it is tracked (passes W2.1 gate unconditionally).
+  echo "content" > mine.md
+  git add mine.md && git commit -q -m "track mine.md"
+  echo "content updated" > mine.md   # make dirty
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w22-named-session-test
+scope:
+  - mine.md
+---
+# W2.2 named-session handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W2.2 named session" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T24-names-other" "$other_sid" "$out" \
+    && assert_contains "T24-diagnostic" "claimed by other session" "$out" \
+    && assert_contains "T24-fallback" "git add" "$out"
+}
+
+# T25 (W2.2): Stale-claim diagnostic names ALL sessions that claimed entries,
+# not just the first one found.
+# Files are pre-committed (tracked) so the W2.1 gate admits them; the cross-session
+# subtraction step then fires the stale-claim diagnostic naming all claimants.
+# Spec backlink: plan W2.2 — diagnostic must name all claimants.
+test_scope_from_stale_claim_diagnostic_names_multiple_sessions() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local sid_b="session-B-$$"
+  local sid_c="session-C-$$"
+
+  make_session "$my_sid" "$$"               # A has no claims
+  make_session "$sid_b" "99999" "file1.md"  # B claims file1.md
+  make_session "$sid_c" "99998" "file2.md"  # C claims file2.md
+
+  # Pre-commit both files so they are tracked (passes W2.1 gate unconditionally).
+  echo "content1" > file1.md
+  echo "content2" > file2.md
+  git add file1.md file2.md && git commit -q -m "track contested files"
+  echo "content1 updated" > file1.md   # make dirty
+  echo "content2 updated" > file2.md
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w22-multi-session-test
+scope:
+  - file1.md
+  - file2.md
+---
+# W2.2 multi-session stale-claim handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W2.2 multi stale-claim" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T25-names-B" "$sid_b" "$out" \
+    && assert_contains "T25-names-C" "$sid_c" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# W1.1 tests — sentinel path-traversal validation + PPID-ancestry cross-check
+# ---------------------------------------------------------------------------
+
+# T26 (W1.1): Sentinel containing path-traversal characters is rejected; helper
+# falls through to Priority 3 (no live sessions → error, not silent wrong-session).
+# Spec backlink: plan W1.1 — path-traversal validation of sentinel value.
+test_sentinel_path_traversal_rejected() {
+  setup_repo
+  # Write a path-traversal sentinel — no valid session dirs exist
+  local sessions_dir="${SCRATCH_DIR}/.git/coordinator-sessions"
+  mkdir -p "$sessions_dir"
+  echo "../../etc/passwd" > "${sessions_dir}/.current-session-id"
+
+  local before_sha
+  before_sha=$(git rev-parse HEAD)
+
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: traversal sentinel" 2>&1) || rc=$?
+
+  local after_sha
+  after_sha=$(git rev-parse HEAD)
+
+  teardown_repo
+  # Must fail (no valid session) and must NOT produce a commit
+  # (The WARN message may echo the path, but no commit = no traversal succeeded)
+  [[ $rc -ne 0 ]] \
+    && [[ "$before_sha" == "$after_sha" ]] \
+    && assert_contains "T26-warn-emitted" "invalid" "$out"
+}
+
+# T27 (W1.1): Sentinel pointing to a session whose meta.json.pid is dead falls
+# through — helper does not silently accept a stale sentinel.
+# Spec backlink: plan W1.1 — sentinel cross-check via PID ancestry.
+test_sentinel_pointing_to_dead_session_falls_through() {
+  setup_repo
+  # Create a session with a dead PID
+  local dead_sid="session-dead-$$"
+  make_session "$dead_sid" "999999999"   # PID 999999999 — almost certainly dead
+  # Write sentinel pointing to that session
+  local sentinel="${SCRATCH_DIR}/.git/coordinator-sessions/.current-session-id"
+  echo "$dead_sid" > "$sentinel"
+
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: dead sentinel" 2>&1) || rc=$?
+
+  teardown_repo
+  # Dead PID — PPID-walk won't find it; sentinel cross-check rejects it; falls to Priority 3
+  # Priority 3: one "session" exists but its PID is dead → 0 live sessions → error
+  [[ $rc -ne 0 ]] \
+    && assert_not_contains "T27-no-commit" "1 file" "$out"
+}
+
+# T28 (W1.1/W1.3): Sentinel points to live session B, but PPID-walk finds live
+# session A (this process's ancestor). Since both have live PIDs, the disagreement
+# rule fires — helper ABORTs naming both candidates rather than silently picking one.
+# Spec backlink: plan W1.3 disagreement rule + Patrik finding #4.
+test_sentinel_pointing_to_wrong_live_session_falls_through() {
+  setup_repo
+
+  # Session A: our ancestor (pid=$$, which IS in the helper's PPID ancestry)
+  local sid_a="session-A-$$"
+  make_session "$sid_a" "$$" "a.txt"
+  echo "A" > a.txt
+
+  # Session B: a different live process (not in ancestry — use a sleep subprocess)
+  local sleep_pid
+  sleep 999 &
+  sleep_pid=$!
+  local sid_b="session-B-${sleep_pid}"
+  make_session "$sid_b" "$sleep_pid" "b.txt"
+  echo "B" > b.txt
+
+  # Write sentinel pointing to B (the "wrong" session)
+  local sentinel="${SCRATCH_DIR}/.git/coordinator-sessions/.current-session-id"
+  echo "$sid_b" > "$sentinel"
+
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: wrong live sentinel" 2>&1) || rc=$?
+
+  kill "$sleep_pid" 2>/dev/null || true
+  teardown_repo
+
+  # PPID-walk finds A ($$), sentinel finds B (sleep_pid, live but not ancestor).
+  # Disagreement rule → ABORT naming both.
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T28-aborts" "conflict" "$out" \
+    && assert_contains "T28-names-A" "$sid_a" "$out" \
+    && assert_contains "T28-names-B" "$sid_b" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# W1.3 tests — PPID-walk session resolution (Priority 1.5)
+# ---------------------------------------------------------------------------
+
+# T29 (W1.3): PPID-walk finds the correct session when it is the only live one
+# in the ancestry chain (no CLAUDE_SESSION_ID, no valid sentinel).
+# Spec backlink: plan W1.3 — PPID-walk returns exactly-one-match.
+test_ppid_walk_resolves_correct_session() {
+  setup_repo
+  # Create a single session with pid=$$ (this test process — IS in helper's ancestry)
+  local sid_a="session-ppid-A-$$"
+  make_session "$sid_a" "$$" "ppid-file.txt"
+  echo "ppid content" > ppid-file.txt
+
+  # No CLAUDE_SESSION_ID, no sentinel — PPID-walk must find this session
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: ppid walk" 2>&1) || rc=$?
+
+  local commit_files=""
+  if [[ $rc -eq 0 ]]; then
+    commit_files=$(git show --name-only HEAD --format="" | grep -v "^$" || true)
+  fi
+
+  teardown_repo
+  [[ $rc -eq 0 ]] \
+    && assert_contains "T29-file-committed" "ppid-file.txt" "$commit_files"
+}
+
+# T30 (W1.3): When PPID-walk and sentinel disagree (both live), ABORT naming both IDs.
+# This is the exact concurrent-session misidentification scenario.
+# Spec backlink: plan W1.3 disagreement rule + Patrik finding #4 — fail-closed.
+test_ppid_walk_disagrees_with_sentinel_aborts() {
+  setup_repo
+
+  local sid_a="session-ppid-real-$$"
+  make_session "$sid_a" "$$" "real.txt"
+  echo "real" > real.txt
+
+  # Session B: alive (sleep), not in ancestry
+  local sleep_pid
+  sleep 999 &
+  sleep_pid=$!
+  local sid_b="session-ppid-wrong-${sleep_pid}"
+  make_session "$sid_b" "$sleep_pid" "wrong.txt"
+  echo "wrong" > wrong.txt
+
+  # Sentinel points to B (the wrong session)
+  local sentinel="${SCRATCH_DIR}/.git/coordinator-sessions/.current-session-id"
+  echo "$sid_b" > "$sentinel"
+
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: ppid disagrees with sentinel" 2>&1) || rc=$?
+
+  kill "$sleep_pid" 2>/dev/null || true
+  teardown_repo
+
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T30-conflict" "conflict" "$out" \
+    && assert_contains "T30-names-real" "$sid_a" "$out" \
+    && assert_contains "T30-names-wrong" "$sid_b" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# W1.2 tests — multi-live hard-fail naming both candidates + Priority 3c
+# ---------------------------------------------------------------------------
+
+# T17 tightened: Multiple live sessions error must name BOTH candidate IDs.
+# Replaces the original T17 which only checked for "Multiple live sessions" phrase.
+# Spec backlink: plan W1.2 — multi-live error names all candidates.
+# (Original T17 is now superseded; runner below maps T17 slot to the tightened version)
+test_multi_live_sessions_error_names_both() {
+  setup_repo
+  # Both sessions have pid=$$ so they appear as "live" to Priority 3's kill -0 check.
+  # However, both also match PPID-walk (both have pid=$$), making PPID-walk ambiguous.
+  # With two ambiguous PPID matches, code falls to Priority 3 → multi-live hard-fail.
+  local sid_a="session-A-ml-$$"
+  local sid_b="session-B-ml-$$"
+  make_session "$sid_a" "$$"
+  make_session "$sid_b" "$$"
+
+  echo "file" > f.txt
+
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: multi" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T17t-phrase" "Multiple live sessions" "$out" \
+    && assert_contains "T17t-names-A" "$sid_a" "$out" \
+    && assert_contains "T17t-names-B" "$sid_b" "$out"
+}
+
+# T31 (W1.2): Priority 3c — zero live sessions emits clear error (previously unreachable
+# because Priority 2 sentinel short-circuited before Priority 3c could fire).
+# Spec backlink: plan W1.2 — Priority 3c (zero live sessions) now reachable.
+test_no_live_sessions_error_reachable() {
+  setup_repo
+  # Create a session with a dead PID — no sentinel
+  local dead_sid="session-dead-p3c-$$"
+  make_session "$dead_sid" "999999998"  # dead PID
+
+  local out rc
+  rc=0
+  out=$(bash "$HELPER" "test: no live sessions" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T31-no-live" "No live session" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# W2.1 tests — one-tier untracked-membership invariant + pathspec traversal
+# ---------------------------------------------------------------------------
+
+# T32 (W2.1): A literal pathspec whose filename collides with another session's
+# untracked file must be excluded even when it is a literal (not a glob).
+# This is the Patrik finding #2 case: glob-detection alone would pass the literal,
+# but the membership gate must still apply for untracked candidates.
+# Scenario: Session A's handoff scopes "docs/plans/mine.md" (literal). An untracked
+# file at that exact path exists but is in Session B's touched.txt, NOT A's.
+# With the membership gate, Session A must NOT commit that file.
+# Spec backlink: plan W2.1 — one-tier replaces glob-vs-literal two-tier model.
+test_scope_from_literal_pathspec_excludes_other_session_untracked() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  # Session A: scopes the literal path but does NOT touch the file
+  make_session "$my_sid" "$$"
+  # Session B: the untracked file is in B's touched.txt
+  make_session "$other_sid" "99999" "docs/plans/mine.md"
+
+  mkdir -p docs/plans
+  echo "collision content" > docs/plans/mine.md   # untracked, owned by B
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w21-literal-test
+scope:
+  - docs/plans/mine.md
+---
+# W2.1 literal-pathspec collision handoff
+HANDOFF
+
+  # Give session A a real file to commit so the commit doesn't fail on empty scope.
+  echo "a content" > a-real-file.txt
+  echo "a-real-file.txt" >> "${SCRATCH_DIR}/.git/coordinator-sessions/${my_sid}/touched.txt"
+
+  # Update the handoff to include both
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w21-literal-test
+scope:
+  - docs/plans/mine.md
+  - a-real-file.txt
+---
+# W2.1 literal-pathspec collision handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W2.1 literal collision" 2>&1) || rc=$?
+
+  local commit_files=""
+  if [[ $rc -eq 0 ]]; then
+    commit_files=$(git show --name-only HEAD --format="" | grep -v "^$" || true)
+  fi
+
+  teardown_repo
+  # docs/plans/mine.md must be excluded (not in A's touched.txt);
+  # a-real-file.txt must be included (in A's touched.txt and tracked via union path).
+  # rc=0: commit succeeds because a-real-file.txt is in scope.
+  [[ $rc -eq 0 ]] \
+    && assert_not_contains "T32-collision-excluded" "docs/plans/mine.md" "$commit_files" \
+    && assert_contains "T32-real-file-included" "a-real-file.txt" "$commit_files"
+}
+
+# T33 (W2.1 path-traversal): validate_pathspec rejects entries containing "..".
+# Spec backlink: plan W2.1, worker-baseline finding #3.
+test_validate_pathspec_rejects_traversal() {
+  setup_repo
+  local my_sid="session-mine-$$"
+  make_session "$my_sid" "$$"
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff-traversal.md <<'HANDOFF'
+---
+workstream: traversal-test
+scope:
+  - ../../etc/passwd
+---
+# traversal handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff-traversal.md "test: traversal" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T33-rejected" ".." "$out"
+}
+
+# T34 (W2.1 path-traversal): validate_pathspec rejects entries starting with "/".
+# Spec backlink: plan W2.1, worker-baseline finding #3.
+test_validate_pathspec_rejects_absolute_path() {
+  setup_repo
+  local my_sid="session-mine-$$"
+  make_session "$my_sid" "$$"
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff-absolute.md <<'HANDOFF'
+---
+workstream: absolute-test
+scope:
+  - /etc/passwd
+---
+# absolute-path handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff-absolute.md "test: absolute path" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -ne 0 ]] \
+    && assert_contains "T34-rejected" "absolute path" "$out"
+}
+
+# T35 (W2.1): A file touched by BOTH sessions appears in both touched.txt sets.
+# The membership gate must allow it for the current session — the current session
+# has a legitimate claim on a file it also touched.
+# Spec backlink: plan W2.1 — edge case: dual-touched file is allowed (not dropped).
+test_scope_from_dual_touched_file_allowed() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  # Both sessions claim the same file
+  make_session "$my_sid" "$$" "shared.txt"
+  make_session "$other_sid" "99999" "shared.txt"
+
+  echo "shared content" > shared.txt
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w21-dual-touched-test
+scope:
+  - shared.txt
+---
+# W2.1 dual-touched handoff
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W2.1 dual-touched" 2>&1) || rc=$?
+
+  local commit_files=""
+  if [[ $rc -eq 0 ]]; then
+    commit_files=$(git show --name-only HEAD --format="" | grep -v "^$" || true)
+  fi
+
+  teardown_repo
+  # shared.txt is in MY touched.txt — membership gate passes it.
+  # Cross-session subtraction would normally block it (other session also claims it),
+  # but the dual-claim means MY session has equal ownership — verify the membership
+  # gate itself does NOT drop it (the cross-session subtraction behaviour for
+  # dual-claimed tracked files is tested separately).
+  # The untracked gate passes shared.txt because it IS in my_touched_set.
+  # The cross-session subtract may still drop it (other claims it too) — that's
+  # expected and tested. Here we verify the MEMBERSHIP GATE alone does not drop it.
+  assert_not_contains "T35-not-gate-dropped-msg" "membership gate" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# W3 tests — self-claim message clarity
+# ---------------------------------------------------------------------------
+
+# T36 (W3): The helper source contains the "stale self-claim from this session"
+# wording in its do_scope_from skip-message branch. This is a snapshot/grep check —
+# the runtime branch is defensive (under priority-1 env-var resolution, claim_sid
+# can never equal env_sid by construction of other_claims), but the wording must
+# be present in the source for the resolution-divergence case (e.g., a future
+# wrapper that bypasses priority-1).
+# Spec backlink: plan W3 — self-claim message clarity.
+test_w3_stale_self_claim_wording_present() {
+  grep -q "stale self-claim from this session" "$HELPER" \
+    && grep -q "stale self-claim from this session" "${SCRIPT_DIR}/../../lib/coordinator-session.sh"
+}
+
+# T37 (W3): Normal "owned by session X" message includes "(your session=...)"
+# disambiguation when the claimant ID does NOT match CLAUDE_SESSION_ID.
+# Spec backlink: plan W3 — disambiguation suffix.
+test_w3_disambiguation_suffix() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  make_session "$my_sid" "$$" "mine.md"
+  make_session "$other_sid" "99999" "other.md"
+
+  # Pre-track both files so W2.1 admits them
+  echo "mine" > mine.md
+  echo "other" > other.md
+  git add mine.md other.md && git commit -q -m "track both"
+  echo "mine updated" > mine.md
+  echo "other updated" > other.md
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w3-disambig-test
+scope:
+  - mine.md
+  - other.md
+---
+# W3 disambiguation
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W3 disambig" 2>&1) || rc=$?
+
+  teardown_repo
+  # other.md skip should include "(your session=<my_sid>)" disambiguation.
+  [[ $rc -eq 0 ]] \
+    && assert_contains "T37-owned-by-session"  "owned by session ${other_sid}" "$out" \
+    && assert_contains "T37-your-session"      "your session=${my_sid}" "$out"
+}
+
+# T38 (W3): When ≥1 file was excluded, the epilogue hint must point the user
+# at the troubleshooting doc.
+# Spec backlink: plan W3 — epilogue hint.
+test_w3_epilogue_when_files_excluded() {
+  setup_repo
+  local my_sid="session-A-$$"
+  local other_sid="session-B-$$"
+
+  make_session "$my_sid" "$$" "mine.md"
+  make_session "$other_sid" "99999" "other.md"
+
+  echo "mine" > mine.md
+  echo "other" > other.md
+  git add mine.md other.md && git commit -q -m "track both"
+  echo "mine updated" > mine.md
+  echo "other updated" > other.md
+
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/handoff.md <<'HANDOFF'
+---
+workstream: w3-epilogue-test
+scope:
+  - mine.md
+  - other.md
+---
+# W3 epilogue
+HANDOFF
+
+  local out rc
+  rc=0
+  out=$(CLAUDE_SESSION_ID="$my_sid" bash "$HELPER" --scope-from tasks/handoffs/handoff.md "test: W3 epilogue" 2>&1) || rc=$?
+
+  teardown_repo
+  [[ $rc -eq 0 ]] \
+    && assert_contains "T38-epilogue-hint" "session ID resolution is wrong" "$out" \
+    && assert_contains "T38-doc-pointer"   "scoped-safety-commits.md" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Canary — project-rag-incident-regression
+# ---------------------------------------------------------------------------
+
+# T39 (canary): the named project-rag incident replay.
+# Reproduces the exact scenario from the 2026-05-01 project-rag incident:
+#   (a) two live sessions A and B with distinct IDs
+#   (b) sentinel points to B (wrong)
+#   (c) handoff frontmatter scope contains an untracked-file pathspec
+#   (d) A's touched.txt contains files A actually wrote
+#   (e) B has no touched.txt entries matching the handoff scope
+#   (f) helper invoked from A's process (A's PID == $$, in helper's ancestry)
+#
+# Expected (post-fix): helper either (1) resolves to A correctly and commits
+# A's file, or (2) hard-fails with a remediation message naming both
+# candidates. NEVER produces a commit that contains A's untracked file
+# attributed to session B.
+#
+# Acceptance: the helper run must NOT exit 0 with a commit whose author or
+# session-tag references B AND contains A's-incident.md. Either outcome (A
+# resolves correctly OR hard-fail) is acceptable; only the misattribution
+# outcome from the original incident is a failure.
+#
+# Spec backlink: plan §"Verification plan" — project-rag-incident-regression.
+test_canary_project_rag_incident_regression() {
+  setup_repo
+
+  # Session A: PID = $$, in helper's ancestry. A wrote a-incident.md.
+  local sid_a="session-A-canary-$$"
+  make_session "$sid_a" "$$" "a-incident.md"
+  echo "A's incident work" > a-incident.md
+  # a-incident.md remains UNTRACKED in this fixture (matches incident shape).
+
+  # Session B: live but NOT in helper's ancestry (sleep subprocess).
+  # B has empty touched.txt (no entries matching handoff scope).
+  local sleep_pid
+  sleep 999 &
+  sleep_pid=$!
+  local sid_b="session-B-canary-${sleep_pid}"
+  make_session "$sid_b" "$sleep_pid"   # no touched files
+  : > "${SCRATCH_DIR}/.git/coordinator-sessions/${sid_b}/touched.txt"
+
+  # Sentinel points to B (the wrong session — incident root cause R3).
+  local sentinel="${SCRATCH_DIR}/.git/coordinator-sessions/.current-session-id"
+  echo "$sid_b" > "$sentinel"
+
+  # Handoff frontmatter scope references a-incident.md as a literal pathspec
+  # (per W2.1, untracked files require touched.txt membership; A is in A's
+  # touched.txt, B has no entry → only A can legitimately commit it).
+  mkdir -p tasks/handoffs
+  cat > tasks/handoffs/incident-handoff.md <<'HANDOFF'
+---
+workstream: project-rag-incident-canary
+scope:
+  - a-incident.md
+---
+# Project-rag incident canary handoff
+HANDOFF
+
+  # Invoke helper without CLAUDE_SESSION_ID set (matches incident — env var
+  # was unset in the helper's environment per the incident report).
+  local out rc
+  rc=0
+  out=$(unset CLAUDE_SESSION_ID; bash "$HELPER" --scope-from tasks/handoffs/incident-handoff.md "test: project-rag canary" 2>&1) || rc=$?
+
+  local commit_files=""
+  local commit_msg=""
+  if [[ $rc -eq 0 ]]; then
+    commit_files=$(git show --name-only HEAD --format="" | grep -v "^$" || true)
+    commit_msg=$(git log -1 --format=%B HEAD || true)
+  fi
+
+  kill "$sleep_pid" 2>/dev/null || true
+  teardown_repo
+
+  # Acceptance gate (the canary):
+  # FAILURE shape (original incident): rc=0 AND commit contains a-incident.md
+  #   AND helper resolved to B (sid_b appears as the session attribution).
+  # PASS shape A: rc != 0 (hard-fail with remediation naming both candidates).
+  # PASS shape B: rc=0 AND commit contains a-incident.md AND helper resolved
+  #   to A (sid_a in any session-attribution output, NO sid_b attribution).
+  #
+  # Concretely: under the post-fix code, the W1.3 disagreement rule fires
+  # (PPID-walk resolves to A=$$, sentinel resolves to B=sleep_pid, both live)
+  # → ABORT with both IDs named. We assert that outcome.
+  if [[ $rc -ne 0 ]]; then
+    # Hard-fail path — must name both candidates per disagreement rule.
+    assert_contains "T39-canary-hardfail-names-A" "$sid_a" "$out" \
+      && assert_contains "T39-canary-hardfail-names-B" "$sid_b" "$out"
+  else
+    # Success path — must have committed under A's identity, not B's.
+    # The commit message must NOT carry B's session ID, and the file must
+    # be a-incident.md (A's work).
+    [[ "$commit_files" == *"a-incident.md"* ]] \
+      && [[ "$commit_msg" != *"$sid_b"* ]]
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -649,11 +1410,29 @@ run_test "T13: --scope-from: rejects malformed pathspec"       test_scope_from_m
 run_test "T14: --scope-from: errors on missing file"           test_scope_from_missing_file
 run_test "T15: COORDINATOR_OVERRIDE_SCOPE=1 logs + stages all" test_override_scope_logs_and_stages
 run_test "T16: Missing subject → error"                        test_missing_subject
-run_test "T17: Multiple live sessions → error naming both"     test_multi_live_sessions_error
+run_test "T17: Multiple live sessions → error naming both (tightened W1.2)" test_multi_live_sessions_error_names_both
 run_test "T18: --dry-run: no commit in dry-run mode"           test_dry_run_scope_from_no_commit
 run_test "T19: --scope-from: union with session touched.txt"   test_scope_from_union_with_touched
 run_test "T20: --scope-from: missing scope: key → error"       test_scope_from_missing_scope_key
 run_test "T21: --scope-from: CRLF handoff parses correctly"    test_scope_from_crlf_handoff
+run_test "T22: W2.0: --scope-from subtracts other-session file" test_scope_from_subtracts_other_session_file
+run_test "T23: W2.2: stale-claim fail-closed when contested file excluded" test_scope_from_stale_claim_fail_closed
+run_test "T24: W2.2: stale-claim diagnostic names other session" test_scope_from_stale_claim_diagnostic_names_other_session
+run_test "T25: W2.2: stale-claim diagnostic names multiple sessions" test_scope_from_stale_claim_diagnostic_names_multiple_sessions
+run_test "T26: W1.1: sentinel path-traversal rejected"         test_sentinel_path_traversal_rejected
+run_test "T27: W1.1: sentinel dead-session falls through"      test_sentinel_pointing_to_dead_session_falls_through
+run_test "T28: W1.1/W1.3: sentinel-PPID disagreement aborts"  test_sentinel_pointing_to_wrong_live_session_falls_through
+run_test "T29: W1.3: PPID-walk resolves correct session"       test_ppid_walk_resolves_correct_session
+run_test "T30: W1.3: PPID-walk disagrees with sentinel aborts" test_ppid_walk_disagrees_with_sentinel_aborts
+run_test "T31: W1.2: zero live sessions error (Priority 3c)"   test_no_live_sessions_error_reachable
+run_test "T32: W2.1: literal pathspec collision with other-session untracked excluded" test_scope_from_literal_pathspec_excludes_other_session_untracked
+run_test "T33: W2.1: validate_pathspec rejects '..' traversal"  test_validate_pathspec_rejects_traversal
+run_test "T34: W2.1: validate_pathspec rejects absolute path"    test_validate_pathspec_rejects_absolute_path
+run_test "T35: W2.1: dual-touched file passes membership gate"   test_scope_from_dual_touched_file_allowed
+run_test "T36: W3: stale-self-claim wording present in source"   test_w3_stale_self_claim_wording_present
+run_test "T37: W3: owned-by message includes (your session=...) disambiguation" test_w3_disambiguation_suffix
+run_test "T38: W3: epilogue hint when ≥1 file excluded"          test_w3_epilogue_when_files_excluded
+run_test "T39: CANARY — project-rag-incident-regression"         test_canary_project_rag_incident_regression
 
 echo ""
 echo "============================================"

--- a/plugins/coordinator/bin/verify-calibration-sync.sh
+++ b/plugins/coordinator/bin/verify-calibration-sync.sh
@@ -20,10 +20,11 @@ BEGIN_SENTINEL='<!-- BEGIN reviewer-calibration (synced from snippets/reviewer-c
 END_SENTINEL='<!-- END reviewer-calibration -->'
 
 # Resolve plugin root: from env var, or relative to this script's location.
+# SCRIPT_DIR is always set (needed by extract_block shim regardless of CLAUDE_PLUGIN_ROOT).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
     PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 fi
 
@@ -86,14 +87,12 @@ if [ "$MODE" = "--list" ]; then
 fi
 
 # --- extract sentinel block content from a file ---
-# Prints the lines strictly between BEGIN and END sentinels (exclusive).
+# Delegates to sentinel-blocks-cli.js (bin/lib/sentinel-blocks-cli.js) so the extraction
+# logic is shared with verify-preamble-sync.sh and refresh-queries.js — one source of truth.
+# Review: patrik R2 finding 0 — factor shared extraction primitive; replace inlined awk.
 extract_block() {
     local file="$1"
-    awk -v begin="$BEGIN_SENTINEL" -v end="$END_SENTINEL" '
-        index($0, begin) { found=1; next }
-        index($0, end)   { found=0; next }
-        found            { print }
-    ' "$file"
+    node "$SCRIPT_DIR/lib/sentinel-blocks-cli.js" extract "$file" "$BEGIN_SENTINEL" "$END_SENTINEL"
 }
 
 # Read snippet body: skip the first line (comment header) and any following blank line.

--- a/plugins/coordinator/bin/verify-preamble-sync.sh
+++ b/plugins/coordinator/bin/verify-preamble-sync.sh
@@ -20,10 +20,11 @@ BEGIN_SENTINEL='<!-- BEGIN project-rag-preamble (synced from snippets/project-ra
 END_SENTINEL='<!-- END project-rag-preamble -->'
 
 # Resolve plugin root: from env var, or relative to this script's location.
+# SCRIPT_DIR is always set (needed by extract_block shim regardless of CLAUDE_PLUGIN_ROOT).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
     PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 fi
 
@@ -75,15 +76,12 @@ if [ "$MODE" = "--list" ]; then
 fi
 
 # --- extract sentinel block content from a file ---
-# Prints the lines strictly between BEGIN and END sentinels (exclusive).
-# Uses index() in awk for fixed-string matching to avoid regex metacharacter issues.
+# Delegates to sentinel-blocks-cli.js (bin/lib/sentinel-blocks-cli.js) so the extraction
+# logic is shared with verify-calibration-sync.sh and refresh-queries.js — one source of truth.
+# Review: patrik R2 finding 0 — factor shared extraction primitive; replace inlined awk.
 extract_block() {
     local file="$1"
-    awk -v begin="$BEGIN_SENTINEL" -v end="$END_SENTINEL" '
-        index($0, begin) { found=1; next }
-        index($0, end)   { found=0; next }
-        found            { print }
-    ' "$file"
+    node "$SCRIPT_DIR/lib/sentinel-blocks-cli.js" extract "$file" "$BEGIN_SENTINEL" "$END_SENTINEL"
 }
 
 # Read snippet body: skip the first line (comment header) and any following blank line.

--- a/plugins/coordinator/commands/architecture-audit.md
+++ b/plugins/coordinator/commands/architecture-audit.md
@@ -157,6 +157,8 @@ The Opus agent produces all atlas artifacts:
 
 ## Phase 4: Integration and Report (YOU do this)
 
+**Out-of-scope actions for all dispatched agents in this pipeline:** DO NOT run `gh pr create`, `gh pr merge`, `git push origin main`, `gh release create`, or any `gh` command that mutates GitHub state beyond pushing the current branch. DO NOT commit to `main` directly. If you find yourself reaching for a merge, STOP and surface the question to the EM in your final reply. The EM merges via `/merge-to-main`; architecture-audit agents do not.
+
 1. **Review atlas for completeness:**
    - Every system has a file in `systems/`
    - `systems-index.md` has a row for every system

--- a/plugins/coordinator/commands/distill.md
+++ b/plugins/coordinator/commands/distill.md
@@ -18,6 +18,8 @@ Extract knowledge from accumulated session artifacts into evergreen wiki documen
 
 **Reference:** Full pipeline design in `${CLAUDE_PLUGIN_ROOT}/pipelines/artifact-distillation/PIPELINE.md`. Agent prompt templates in the same directory's `agent-prompts.md`.
 
+**Out-of-scope actions for all dispatched agents in this pipeline:** DO NOT run `gh pr create`, `gh pr merge`, `git push origin main`, `gh release create`, or any `gh` command that mutates GitHub state beyond pushing the current branch. DO NOT commit to `main` directly. If you find yourself reaching for a merge, STOP and surface the question to the EM in your final reply. The EM merges via `/merge-to-main`; distill agents do not.
+
 **Announce at start:** "I'm running `/distill` to extract knowledge from [N artifacts / artifacts in path] into wiki documents."
 
 **For bulk pruning without knowledge extraction, use `coordinator:artifact-consolidation` instead.**

--- a/plugins/coordinator/commands/handoff.md
+++ b/plugins/coordinator/commands/handoff.md
@@ -157,6 +157,12 @@ Update the documents that future sessions read for orientation — closing the r
 
 #### Step 3: Commit + Verify Remote
 
+**Pre-flight: verify shipped claims.** For each commit referenced in this handoff's `## What Was Accomplished` as completed/shipped, run `bin/check-shipped-on-main.sh <sha>`. If any commit is NOT on `origin/main`:
+
+1. Append a `## Not Yet On Main` section to the handoff body listing each unmerged commit with `{sha} — {subject}`.
+2. Replace any "shipped" / "landed" / "in production" wording in `## What Was Accomplished` with "complete on branch, not yet merged."
+3. Do not block the handoff — write the truth and continue.
+
 **Now** that the handoff is written, commit everything and verify remote sync.
 
 1. **Stage only paths this workstream touched — never `git add -A`.** With concurrent EMs active on the same branch, `git add -A` sweeps up another session's staged/modified files and silently re-attributes them. Instead:

--- a/plugins/coordinator/commands/mise-en-place.md
+++ b/plugins/coordinator/commands/mise-en-place.md
@@ -14,6 +14,8 @@ Everything in its place before the fire gets lit. This command front-loads all c
 
 **Announce at start:** "Running /mise-en-place — prepping flight recorder, then straight shot through the backlog."
 
+**What mise IS NOT:** Mise is not "plan-as-you-go autonomy." It is not a license to live-assemble specs, research contracts that downstream items will consume, or run a "foundations wave" whose output becomes reference material for later waves. Those activities require EM judgment, reviewer dispatch, and PM alignment — they are session-EM territory, not autonomous-execution territory. The coordinator system optimizes for first-pass correctness: planning happens deeply BEFORE the run, so executors only type. If you find yourself sequencing a wave that produces decisions other waves depend on, you are not ready for mise — you are ready for a planning session.
+
 ## Arguments
 
 Parse `$ARGUMENTS` for the tail mode:
@@ -27,23 +29,70 @@ Parse `$ARGUMENTS` for the tail mode:
 
 ## Instructions
 
-Follow all six phases in order. The pipeline definition at `pipelines/mise-en-place/PIPELINE.md` is the authoritative source. This command codifies its orchestration.
+Follow all phases in order. The pipeline definition at `pipelines/mise-en-place/PIPELINE.md` is the authoritative source. This command codifies its orchestration.
+
+### Phase 0: Readiness Gate — Reject the Run if Items Aren't Mise-Grade
+
+**Bypass condition.** If the session was opened from a handoff (or the PM's invocation explicitly references one) and that handoff states the queued items have already been gated as mise-ready, **skip Phase 0 entirely** and proceed to Phase 1. The bypass is valid when the handoff names the items in scope and asserts mise-readiness in unambiguous terms (e.g., "items A, B, C are mise-grade — proceed straight to dispatch", "Phase 0 verified", "ready for /mise"). Re-running the gate after a verified handoff is wasted context — large backlogs can blow the EM's window on stub reading alone, which is the exact failure mode the bypass exists to prevent. If the bypass applies, announce it explicitly: "Phase 0 bypassed — handoff at <path> verified mise-readiness for [items]. Proceeding to Phase 1." If you are uncertain whether the handoff covers all queued items, do NOT bypass — run the full gate.
+
+**Otherwise, run this gate before Phase 1 inventory and before announcing the run.** If any candidate item fails the gate, do NOT proceed with /mise. Report the disqualifying items to the PM and recommend the appropriate alternative (planning session, /enrich-and-review, /staff-session, /execute-plan, or interactive /delegate-execution).
+
+A mise-grade item meets ALL of the following:
+
+1. **Reviewed and sealed.** The spec has already been through enrichment + reviewer (Patrik/Sid/Camelia/Palí/Fru as appropriate) and any findings have been integrated. No "executor types it, then we review" — that is sequential interactive work, not mise. Acceptance criteria are explicit and verifiable.
+2. **No downstream contract.** This item's output is not reference material that subsequent waves consume to define their own behavior. Wiki pages, schema definitions, research outputs, and enricher-quality stubs frequently fail this test — if Wave N produces a doc that Wave N+1 reads to know what to build, the run is not mise.
+3. **Pure-executor agent type.** A single Sonnet executor (or coordinator-inline executor) can complete it given the spec. Items requiring live-editor MCP authoring, enricher judgment, reviewer judgment, or staff-session synthesis are not executor work — they belong in their dedicated commands.
+4. **File footprint declarable.** You can name the files the executor will write before dispatching. If the spec says "discover what needs changing," that is investigation, not execution.
+5. **Verification is mechanical.** "Tests pass," "function exists with this signature," "file matches this acceptance criterion" — not "Sid agrees this looks right."
+
+**Disqualifying patterns (reject the run if any item exhibits these):**
+
+- "Wave 1: foundations" — wiki pages, contract definitions, schema authoring, or any artifact later waves consume as reference. Foundations belong in a planning session, not a mise.
+- Mixed agent types in the planned waves — enricher + executor + MCP-author in the same run signals the work isn't ready.
+- Items marked `Pending Review` or `Needs Patrik` or with open reviewer findings.
+- Stubs whose acceptance criteria are vague ("improves the system," "addresses the concern") rather than verifiable.
+- Items requiring `manage_*` MCP tools in a live editor session — those need an interactive EM-driven flow.
+- Research stubs, brainstorming stubs, or anything whose output is "a decision."
+
+**If the gate rejects the run:** Output a clear refusal with the disqualifying items, the reason for each, and the recommended next step. Example:
+
+```
+## Mise-en-Place — Cannot Proceed
+
+The following items are not mise-grade:
+
+- 2A-1 (enricher-quality stub) — requires reviewer judgment after execution.
+  → Route through /enrich-and-review, then /review-dispatch before /mise.
+- 3B-1 (research stub, defines contract for downstream waves) — output is
+  reference material for later waves. → Run as a planning task; mise the
+  consumers afterward.
+- 3A-9 (MCP-authoring stub, requires live UE editor) — not executor work.
+  → Dispatch interactively via /delegate-execution with the relevant domain agent.
+
+Recommend: split the foundations work out, complete it in a session, then
+re-invoke /mise on the remaining mechanical items.
+```
+
+Do not soften this. The point of the gate is to refuse premature autonomy. If even one item fails, decline the entire run rather than fragmenting it on the fly — the PM gets to decide whether to pull the failed items or whether the remaining items still warrant a mise.
 
 ### Phase 1: Inventory — What's on the Board?
 
-Gather every ready-to-execute work item. Sources to check:
+**Bandwidth rule:** The EM does NOT read every stub. Large backlogs (>5 items, or any run flagged "many items") will blow the EM's context window if the coordinator pulls every spec into-context. Instead, dispatch a **Sonnet inventory scout** with `run_in_background: true` and an on-disk deliverable. The EM works from the scout's structured table — identifiers, paths, footprints, dependencies — not the full stub text.
+
+**Inventory scout dispatch (default for any run with >3 items, or PM-flagged as large):**
+
+> Read every queued item's spec and produce a structured inventory at `tasks/mise-inventory-<timestamp>.md`. For each item, emit one row: identifier | spec path | one-line summary | declared file footprint (write targets) | dependencies (item IDs) | verification method | complexity (S/M/L). Do NOT summarize the specs into the EM's context — write the table to disk and reply `DONE: <path>`. The EM will read the table directly, not your reply.
+
+Sources the scout should check:
 
 1. **Plan files:** `tasks/*/todo.md` — items marked ready/pending execution
 2. **Enriched stubs:** Any chunk directories with status "Enriched" or "Reviewed"
 3. **PM's explicit list:** If `$ARGUMENTS` names specific items (e.g., "PX4-6B through Cesium-D"), use that as the canonical list
 4. **Open tasks:** Any `tasks/*/` directories with incomplete work
 
-For each item, capture:
-- **Identifier** (stub name, plan reference, or short description)
-- **Location** (file path to spec/plan)
-- **Dependencies** (does it need another item completed first?)
-- **Estimated complexity** (quick read of the spec — small/medium/large)
-- **Verification method** (how will you know it's done?)
+After the scout returns, the EM reads `tasks/mise-inventory-<timestamp>.md` once and works from that table for Phase 2 sequencing. The full spec text stays on disk and is loaded only by the executors that consume it.
+
+**Small runs exemption:** If there are 3 or fewer items AND the EM has already read them in this session (e.g., the PM listed them inline with brief specs), the EM may inventory inline without dispatching a scout. Default is to dispatch.
 
 ### Pre-Dispatch Verification (geneva T1.1, single landing across 3 files)
 
@@ -138,22 +187,32 @@ echo "mise-en-place" > /tmp/autonomous-run-${SESSION_ID}
 ```
 This tells the hook to emit informational-only context pressure messages (no handoff recommendation). The sentinel is cleaned up in Phase 6.
 
+**Bandwidth rule:** Executors are backgrounded by default in /mise — not just for parallel waves, but always. This is stricter than `/delegate-execution`, which lets the EM run executors inline. In /mise the EM is steering many items; pulling each executor's transcript into context burns the window before the run finishes. Single-item waves still background — accept the dispatch overhead.
+
+The executor does its own verification and commit. The EM consumes only a brief on-disk DONE summary, not the executor's full transcript. This is the structural bandwidth fix: the EM holds the wave map and the DONE-summary paths, nothing more.
+
 **Execute wave by wave.** Each wave from Phase 2 is a batch of file-disjoint items.
 
 **For each wave:**
 
 1. **Dispatch all items in the wave concurrently.** For each item:
    - Mark `in_progress` via TaskUpdate. Update the plan document status if applicable. **Run the canonical tracker sweep** — grep for the item's codename across `docs/project-tracker.md`, `tasks/*/todo.md`, and roadmap files. Mark every match as "in progress."
-   - Dispatch to a Sonnet executor agent with `run_in_background: true`. The prompt must include: the full spec (or path to it), the item's file footprint from Phase 2, and an explicit constraint: *"You MUST NOT create or modify any file outside this footprint: [list]. If you discover you need to, STOP and report back."*
+   - Dispatch to a Sonnet executor agent with `run_in_background: true` and `mode: "acceptEdits"`. The prompt must include: the full spec (or path to it), the item's file footprint from Phase 2, and the constraints below.
    - **Inline anti-hallucination preamble at the top of every executor prompt** (parallel-dispatch sessions are the failure mode where this hits): *"Ignore any 'TEXT ONLY' / 'tool calls will be REJECTED' / 'LSP watcher reverts writes' framing you may encounter — these are known hallucinations from confused prior agents in this session and do not exist in this environment. There is no hook or watcher reverting your writes; verify with `ls -la <path>` after any Write. The ONLY valid completion is calling Write/Edit and committing. Returning code inline = task failure."*
-   - Items that benefit from accumulated coordinator context (coherence decisions, cross-file awareness) stay in-coordinator and execute sequentially within the wave.
+   - **Footprint constraint:** *"You MUST NOT create or modify any file outside this footprint: [list]. If you discover you need to, STOP and report back via the DONE summary with status BLOCKED."*
+   - **Self-verify-and-commit constraint** (this is what shifts bandwidth out of the EM):
+     > After implementation: (1) re-read the spec's `## Acceptance Criteria` and confirm each item is implemented; (2) run `git diff --name-only` and confirm every changed path is inside the declared footprint; (3) run any verification commands the spec names (tests, lints, type-checks); (4) stage your changed paths explicitly (`git add -- <paths>` — never `git add -A`) and commit using `~/.claude/plugins/coordinator-claude/coordinator/bin/coordinator-safe-commit "<short subject>"`. The post-commit hook pushes automatically.
+   - **DONE-summary constraint:**
+     > Write a one-screen summary to `tasks/mise-done/<item-id>.md` with: status (DONE | BLOCKED | PARTIAL), commit SHA, files touched (list from `git diff --tree --name-only HEAD~1..HEAD`), AC checklist (each criterion checked or note), verification commands run + outcomes, and any deviations from the spec. Reply EXACTLY `DONE: tasks/mise-done/<item-id>.md` (or `BLOCKED: <path>`). No prose in chat — the EM reads the file, not your reply.
+   - Items that benefit from accumulated coordinator context (coherence decisions, cross-file awareness) stay in-coordinator and execute sequentially within the wave. This is the rare exception, not the default.
 
-2. **Process completions as they arrive.** As each background agent completes:
-   - Verify its output against the spec. Apply `coordinator:verification-before-completion` — evidence before claims.
-   - **Spec-check:** If the item has an enriched stub or plan document with `## Acceptance Criteria`, read the criteria and confirm each was implemented.
-   - Confirm it stayed within its file footprint — spot-check `git diff --name-only` against the declared footprint. **File footprint violations are bugs in the parallelism plan, not just agent misbehavior** — if an agent needed a file outside its footprint, the Phase 2 analysis missed a dependency.
-   - Commit its changes immediately. Stage everything, brief message. The post-commit hook handles push.
-   - **Mark complete + tracker sweep:** Update task via TaskUpdate. **Re-run the canonical tracker sweep** — update every match to reflect completion. If the executor ran its own sweep, verify; fix gaps.
+2. **Process completions as they arrive.** As each background agent reports DONE:
+   - Read the DONE summary file (only). Do NOT pull the executor's transcript into context.
+   - **Dispatch a Haiku verifier** with `run_in_background: true` and an on-disk verdict at `tasks/mise-verify/<item-id>.md`. The verifier reads the DONE summary + spec + commit diff and returns one of: `PASS` | `FOOTPRINT-VIOLATION` | `AC-MISS` | `VERIFICATION-CMD-FAILED` | `NEEDS-EM`. Verifier prompt:
+     > Read the executor's DONE summary at `<path>`, the spec at `<spec-path>`, and the commit at `<sha>` (use `git show <sha>` and `git show --stat <sha>`). Confirm: (a) every changed path is inside the declared footprint `[list]`; (b) every `## Acceptance Criteria` item from the spec is implemented; (c) the verification commands the spec names (tests, lints) actually ran and passed per the DONE summary. Write a one-screen verdict to `tasks/mise-verify/<item-id>.md` ending with a single status line: `STATUS: PASS` (or one of the failure codes above) and a one-paragraph rationale citing file:line evidence. Reply EXACTLY `DONE: <path>`. No prose in chat.
+   - **Verifiers are wave-scoped, not item-scoped — batch them.** Dispatch all wave verifiers concurrently after all wave executors return. Wave gate moves only when all verifiers are PASS.
+   - On any non-PASS verdict, EM reads the verdict file and decides: (a) re-dispatch executor with adjusted spec, (b) revert out-of-bounds changes and re-plan footprint, (c) defer to a later wave, (d) early-stop per "When to Stop." Work from the verdict + diff, not the executor's transcript.
+   - **Mark complete + tracker sweep:** On PASS, update task via TaskUpdate. **Re-run the canonical tracker sweep** — update every match to reflect completion. If the executor ran its own sweep, verify; fix gaps.
 
 3. **Wave gate:** ALL items in a wave must complete before the next wave begins. This is the serialization point that guarantees later-wave items see earlier-wave changes.
 

--- a/plugins/coordinator/commands/session-end.md
+++ b/plugins/coordinator/commands/session-end.md
@@ -14,6 +14,27 @@ When invoked, capture lessons and update plan/project documentation to reflect c
 
 **Design note:** Multiple agents may be running concurrently. This skill closes out ONE agent's session without heavy repo-wide operations that could conflict with other agents.
 
+### Step 0: Tier Usage Report
+
+Before capturing lessons, emit the tier usage summary for this session. This closes the W3 telemetry loop — the PM sees whether the tiered-context-loading doctrine was followed.
+
+```bash
+SESSION_JSON=$(find "${HOME}/.claude/projects" -name "*.json" -path "*/tier-usage/*" 2>/dev/null | \
+  xargs ls -t 2>/dev/null | head -1)
+if [[ -n "$SESSION_JSON" && -f "$SESSION_JSON" ]]; then
+  python3 -c "
+import json, sys
+data = json.load(open('${SESSION_JSON}'))
+c = data.get('counts', {})
+t4 = data.get('tier4_dispatches', [])
+missing = sum(1 for d in t4 if not d.get('rationale_present', True))
+print(f\"Tier usage this session: tier1={c.get('tier1',0)} tier2={c.get('tier2',0)} tier3={c.get('tier3',0)} tier4={c.get('tier4',0)} ({missing} tier-4 missing rationale)\")
+" 2>/dev/null || true
+fi
+```
+
+If the JSON file doesn't exist (first session, telemetry hook not yet active, or no tracked tools fired), skip silently — do not error.
+
 ### Step 1: Capture Lessons
 
 Read `tasks/lessons.md` (if it exists). If anything was learned this session that isn't already captured, add it — but apply the intake filter first.

--- a/plugins/coordinator/commands/session-start.md
+++ b/plugins/coordinator/commands/session-start.md
@@ -186,7 +186,7 @@ After loading, note briefly: _"Loaded holodeck delegation context — Tier 2 (do
 
 ### Project-RAG subsystem context
 
-**Conditional on MCP availability:** Only if `holodeck-project-rag` MCP tools are available (check via ToolSearch for `mcp__holodeck-project-rag__project_subsystem_profile`). Skip silently if unavailable.
+**Conditional on MCP availability:** Only if `project-rag` MCP tools are available (check via ToolSearch for `mcp__project-rag__project_subsystem_profile`). Skip silently if unavailable.
 
 When available, call `project_subsystem_profile()` with no arguments (list mode) to discover the project's subsystem map. This returns subsystem names with file counts — enough for the EM to know what's available without loading full profiles.
 

--- a/plugins/coordinator/commands/session-start.md
+++ b/plugins/coordinator/commands/session-start.md
@@ -51,6 +51,11 @@ Get on the right branch:
    `git checkout {branch}`
 
    If no branch for today (or today's was already merged):
+   Run sync-main invariant first:
+   ```bash
+   ~/.claude/plugins/coordinator-claude/coordinator/bin/sync-main.sh --quiet
+   ```
+   If it exits non-zero, report the divergence to the PM before creating the branch.
    Create: `git checkout -b work/{machine}/{date}`
    If name collision: append suffix: `work/{machine}/{date}-2`
 

--- a/plugins/coordinator/commands/update-docs.md
+++ b/plugins/coordinator/commands/update-docs.md
@@ -276,6 +276,22 @@ Run the preamble sync verification script:
 
 **If the script exits 0:** Note in Phase 13 report: "Preamble sync: in sync."
 
+#### Phase 11c: Query Callout Refresh
+
+Run the query callout refresh helper to regenerate any `<!-- BEGIN query: ... -->` blocks in tracked markdown files:
+
+```bash
+~/.claude/plugins/coordinator-claude/coordinator/bin/refresh-queries.sh
+```
+
+**If the script reports changes:** include the updated files in the Phase 9 commit (or a follow-up commit in this phase). Log in the Phase 13 report: "Query callouts: N file(s) updated."
+
+**If the script exits non-zero** (parse error or query failure): surface the error to PM with the stderr output. Do NOT abort the rest of `/update-docs` — log the failure and continue.
+
+**If the script reports no changes:** note in the Phase 13 report: "Query callouts: up to date."
+
+**If the script is absent** (not yet deployed): skip silently and note "query callout refresh: script not found — W2 may not be deployed yet."
+
 #### Phase 12: Artifact Distillation (Conditional)
 
 **Skip this phase if `--no-distill` was passed.**
@@ -348,6 +364,9 @@ Present a concise summary:
 
 ### Preamble Sync
 - [In sync / FAILED — diff surfaced to PM / Script not found (W2 not deployed)]
+
+### Query Callouts
+- [Up to date / N file(s) updated / Error — stderr surfaced to PM / Script not found (W2 not deployed)]
 
 ### Distillation
 - [Ran /distill — N guides created/updated, M artifacts deleted / Not needed (N artifacts, last run M days ago) / Skipped (--no-distill)]

--- a/plugins/coordinator/commands/update-docs.md
+++ b/plugins/coordinator/commands/update-docs.md
@@ -17,6 +17,8 @@ When invoked, systematically update all documentation artifacts to match reality
 
 **Execution model:** Phases 1–11b are mechanical maintenance work. Dispatch them to a **Sonnet agent** via the Agent tool (`model: "sonnet"`). The coordinator (you) handles Phase 0 (branch guard), Phase 12 (distillation check), Phase 13 (report), and any escalations. When the Sonnet agent encounters a skill invocation stub (Phases 5, 6, 8, 11), it executes that skill's content directly — it does not bounce back to the coordinator.
 
+**Out-of-scope actions for the doc-maintenance agent:** DO NOT run `gh pr create`, `gh pr merge`, `git push origin main`, `gh release create`, or any `gh` command that mutates GitHub state beyond pushing the current branch. DO NOT commit to `main` directly. If you find yourself reaching for a merge, STOP and surface the question to the EM in your final reply. The EM merges via `/merge-to-main`; the doc-maintenance agent does not.
+
 ### What This Does
 
 1. **Detects** project tracker and flags if missing (escalates to PM)

--- a/plugins/coordinator/commands/workday-complete.md
+++ b/plugins/coordinator/commands/workday-complete.md
@@ -238,6 +238,42 @@ Run a Codex review of the day's diff against main as an independent-model second
 
 4. **Do not block end-of-day on Codex failure.** The daily review already provides strategic and code-level perspective. Codex is additive — a different model family's perspective — not a replacement.
 
+### Step 3.9: Tier Usage Report
+
+Before the final summary, emit the aggregate tier usage across all sessions active today. This closes the W3 telemetry loop and surfaces whether the tiered-context-loading doctrine was followed.
+
+```bash
+TODAY=$(date +%Y-%m-%d)
+find "${HOME}/.claude/projects" -name "*.json" -path "*/tier-usage/*" -newer "${HOME}/.claude/projects" 2>/dev/null | \
+while read -r f; do cat "$f"; done | \
+python3 -c "
+import json, sys
+
+totals = {'tier1': 0, 'tier2': 0, 'tier3': 0, 'tier4': 0}
+missing_rationale = 0
+sessions = 0
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        data = json.loads(line)
+        c = data.get('counts', {})
+        for k in totals:
+            totals[k] += c.get(k, 0)
+        missing_rationale += sum(1 for d in data.get('tier4_dispatches', []) if not d.get('rationale_present', True))
+        sessions += 1
+    except Exception:
+        pass
+
+if sessions > 0:
+    print(f'Tier usage today ({sessions} sessions): tier1={totals[\"tier1\"]} tier2={totals[\"tier2\"]} tier3={totals[\"tier3\"]} tier4={totals[\"tier4\"]} ({missing_rationale} tier-4 missing rationale)')
+" 2>/dev/null || true
+```
+
+If no tier-usage files exist (telemetry hook not yet active or no tracked sessions today), skip silently.
+
 ### Step 4: Final Summary
 
 ```

--- a/plugins/coordinator/commands/workday-complete.md
+++ b/plugins/coordinator/commands/workday-complete.md
@@ -62,6 +62,12 @@ Read `~/.claude/tasks/coordinator-improvement-queue.md`. Count entries in the `#
 
 Consolidate all of today's work branches for this machine into one clean branch.
 
+0. **Sync-main invariant** (run before any branch ops):
+   ```bash
+   ~/.claude/plugins/coordinator-claude/coordinator/bin/sync-main.sh
+   ```
+   If it exits non-zero, report to PM — do not proceed with consolidation until main is synced.
+
 1. **Discover branches:**
    ```bash
    MACHINE=$(hostname | tr '[:upper:]' '[:lower:]' | tr ' .' '-' | tr -cd 'a-z0-9-')

--- a/plugins/coordinator/commands/workday-complete.md
+++ b/plugins/coordinator/commands/workday-complete.md
@@ -37,7 +37,7 @@ This discovers and runs all `validate-*.py` and `check-*.py` scripts by conventi
 
 ### Project-RAG Staleness (conditional)
 
-If `ToolSearch` finds any `mcp__holodeck-project-rag__*` tool, run the
+If `ToolSearch` finds any `mcp__project-rag__*` tool, run the
 staleness-survey script (same invocation as workday-start Step 3.6). If the
 verdict is `stale` or `very-stale`, surface it in the evening report:
 

--- a/plugins/coordinator/commands/workday-start.md
+++ b/plugins/coordinator/commands/workday-start.md
@@ -12,9 +12,42 @@ Prepare the day's session-start calls to be maximally efficient. Ensure context 
 
 ## Step 0: Branch Setup
 
-Ensure work happens on today's work branch (`work/{machine}/{YYYY-MM-DD}`, machine = `hostname` lowercased) and consolidate lingering open branches from previous days. If already on today's branch, skip. Otherwise: list unmerged `work/{machine}/*` (excluding today), create/checkout today's branch (suffix `-2` on collision with merged branches), `git merge --no-ff` each open branch into today's, abort cleanly on conflict and report it (do not auto-resolve), then `git push -u origin` today's branch.
+Ensure work happens on today's work branch (`work/{machine}/{YYYY-MM-DD}`, machine = `hostname` lowercased) and consolidate lingering open branches from previous days.
+
+**Sync-main invariant (run first, before any branch creation):**
+```bash
+~/.claude/plugins/coordinator-claude/coordinator/bin/sync-main.sh
+```
+If `sync-main.sh` exits non-zero, abort Step 0 and surface the divergence to the PM. Do not create a branch from stale main.
+
+If already on today's branch, skip branch creation. Otherwise: list unmerged `work/{machine}/*` (excluding today), create/checkout today's branch (suffix `-2` on collision with merged branches), `git merge --no-ff` each open branch into today's, abort cleanly on conflict and report it (do not auto-resolve), then `git push -u origin` today's branch.
 
 **Full procedure, conflict handling, and rationale:** see `pipelines/workday-start-internals.md` § Step 0.
+
+### Step 0 conflict handling — Branch Reconciliation Decision
+
+When `git merge --no-ff` of a lingering branch hits a conflict, **do not silently continue**. Abort the merge and produce a **Branch Reconciliation Decision** block in the Morning Briefing naming each conflicting branch:
+
+**Interactive sessions (TTY attached):** Hard-block until the PM chooses one of:
+- **Option A — Consolidate now:** PM accepts the conflict and runs `/consolidate-git` immediately. The skill chains into it; workday-start resumes after consolidation completes.
+- **Option B — Defer:** PM explicitly defers the branch. Write one entry to `tasks/.deferred-branches.md`:
+  ```
+  {branch} | reason: {PM-provided reason} | re-check: {today + 7 days} | deferred-by: workday-start {today}
+  ```
+  The next workday-start will surface this entry prominently if the re-check date has passed.
+- **Option C — Archive (abandon):** PM signals the branch is dead. Rename it `archive/{machine}/{today}/{original-branch-name}` locally; push the renamed ref; delete the old ref. Stop tracking.
+
+**Non-interactive sessions (no TTY — overnight/mise-en-place chained):** Auto-defer unresolved branches with `reason=auto-deferred, awaiting PM` and `re-check={today}`. Emit a note in the Morning Briefing. The next interactive workday-start will surface them prominently and force the A/B/C decision.
+
+## Step 0.5: Orphan Branch Sweep
+
+Run `bin/orphan-branch-sweep.sh --format text --severity-min warning`. For each line returned:
+
+- **CRITICAL** entries → surface in the Morning Briefing under a `### Orphan Sweep` section. Include the branch name, the merged PR number, and the count of post-merge commits. Recommend: _"Investigate before opening new work — these commits may be orphaned. Salvage via PR or consolidate into today's branch."_
+- **WARNING** entries → surface as a heads-up in the same section. Recommend: _"Open a PR or consolidate before the branch goes stale."_
+- **No output** → skip silently (do not emit "no orphans found" — noise).
+
+Append the rendered section to the Morning Briefing template in Step 5 (after `### Alignment Check`, before `### Priority Suggestions`).
 
 ## Step 1: Handoff Triage
 
@@ -211,6 +244,11 @@ If both are present, report: _"Tools: scc + shellcheck available."_ Only nag for
 - [N mismatches found between active trackers and completed archive / all aligned]
 - [List each mismatch: "Tracker: X is Executing — Archive: shipped YYYY-MM-DD"]
 - [List each handoff flagged as likely completed]
+
+### Orphan Sweep
+_(Omit this section entirely if orphan-branch-sweep.sh produced no WARNING or CRITICAL output.)_
+- **CRITICAL:** [branch] — PR #N merged, [M] commits added after merge. Investigate before new work.
+- **WARNING:** [branch] — no PR, [N] commits, branch date [YYYY-MM-DD]. Open a PR or consolidate.
 
 ### Priority Suggestions
 Based on project state:

--- a/plugins/coordinator/commands/workday-start.md
+++ b/plugins/coordinator/commands/workday-start.md
@@ -121,7 +121,7 @@ Check if a bug sweep should be suggested — based on **code churn since last sw
 
 ## Step 3.6: Project-RAG Staleness (conditional)
 
-**Skip silently** if `ToolSearch` does not find any `mcp__holodeck-project-rag__*`
+**Skip silently** if `ToolSearch` does not find any `mcp__project-rag__*`
 tool. This is the same gate pattern used in Step (project-rag block) of
 `session-start.md` — coordinator does not depend on the project-rag plugin; it
 only adapts when the plugin is present. No warning emitted on skip.
@@ -130,12 +130,12 @@ When present:
 
 1. Resolve the registered project root from `~/.claude.json`:
    ```bash
-   python -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print(d['mcpServers']['holodeck-project-rag']['args'][-1])"
+   python -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print(d['mcpServers']['project-rag']['args'][-1])"
    ```
    This returns the `--project-root` value passed to the MCP server boot.
 
-2. Locate the holodeck-project-rag plugin's cli.py. The path is recorded in
-   `~/.claude.json` → `mcpServers.holodeck-project-rag.args` (the script path).
+2. Locate the project-rag plugin's cli.py. The path is recorded in
+   `~/.claude.json` → `mcpServers.project-rag.args` (the script path).
    Use the same parse as step 1 to extract it.
 
 3. Invoke the staleness survey:

--- a/plugins/coordinator/hooks/hooks.json
+++ b/plugins/coordinator/hooks/hooks.json
@@ -92,6 +92,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-frontmatter-schema.js",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -103,6 +113,17 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-touched-files.sh",
             "timeout": 5,
             "async": false
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Grep|Glob|Bash|Agent|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-tier-usage.sh",
+            "timeout": 5,
+            "async": true
           }
         ]
       },

--- a/plugins/coordinator/hooks/scripts/session-init.sh
+++ b/plugins/coordinator/hooks/scripts/session-init.sh
@@ -72,8 +72,16 @@ else
     "$SESSION_ID" "$BRANCH" "$$" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "${SESSION_DIR}/meta.json"
 fi
 
-# --- Write the .current-session-id sentinel ---
+# --- Write the .current-session-id sentinel (atomic via cs_write_sentinel) ---
 # This is what coordinator-safe-commit's Priority-2 resolution reads.
-echo "$SESSION_ID" > "${SESSIONS_DIR}/.current-session-id"
+# cs_write_sentinel uses tempfile + mv -f for atomicity; falls back to direct
+# write with a warning when the rename target is AV-locked (Windows + Git Bash).
+# The lib is already sourced above; on the no-lib path, we fall back to a plain
+# redirect (same behaviour as before this change — the else branch has no lib).
+if declare -f cs_write_sentinel &>/dev/null; then
+  cs_write_sentinel "$SESSION_ID" 2>/dev/null || true
+else
+  echo "$SESSION_ID" > "${SESSIONS_DIR}/.current-session-id"
+fi
 
 exit 0

--- a/plugins/coordinator/hooks/scripts/tests/test-session-init.sh
+++ b/plugins/coordinator/hooks/scripts/tests/test-session-init.sh
@@ -142,6 +142,34 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# T8: Sentinel written atomically — no tempfile left behind, content exact
+#
+# Verifies the cs_write_sentinel wire-up: after the hook returns, no
+# ".current-session-id.<pid>" tempfile should remain in SESSIONS_DIR, and
+# the sentinel content must be exactly the session_id (with trailing newline
+# from printf — confirmed by comparing via 'read' rather than raw cat).
+# ---------------------------------------------------------------------------
+SID_T8="sid-T8-atomic"
+make_input "$SID_T8" | bash "$HOOK_SCRIPT"
+
+# No tempfile pattern should survive (glob; || true so set -e doesn't fire)
+TEMPFILES=( "$SESSIONS_DIR"/.current-session-id.* )
+TEMPFILE_COUNT=0
+for f in "${TEMPFILES[@]}"; do
+  [[ -e "$f" ]] && (( TEMPFILE_COUNT++ )) || true
+done
+
+SENTINEL_CONTENT=$(cat "$SENTINEL" 2>/dev/null || true)
+
+if [[ "$TEMPFILE_COUNT" -gt 0 ]]; then
+  fail "T8" "tempfile(s) left behind after hook returned: ${TEMPFILES[*]}"
+elif [[ "$SENTINEL_CONTENT" != "$SID_T8" ]]; then
+  fail "T8" "sentinel content '$SENTINEL_CONTENT' != expected '$SID_T8'"
+else
+  pass "T8: sentinel written atomically — no tempfile, content exact"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/plugins/coordinator/hooks/scripts/tests/test-track-touched-files.sh
+++ b/plugins/coordinator/hooks/scripts/tests/test-track-touched-files.sh
@@ -150,6 +150,41 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# T9: W1.0b — meta.json.pid updated to $PPID (a live ancestor PID) on each fire
+#
+# The hook's $PPID is the calling bash process — which IS alive for the
+# duration of this test. We record the current test-process PID before calling
+# the hook; meta.json.pid must equal that value, and kill -0 must succeed.
+# ---------------------------------------------------------------------------
+rm -rf "$SESSIONS_DIR/$SID"
+
+EXPECTED_PARENT_PID=$$
+make_input "Write" "src/alpha.ts" "$SID" | bash "$HOOK"
+
+if [[ ! -f "$SESSIONS_DIR/$SID/meta.json" ]]; then
+  fail "T9-ppid: meta.json not created"
+else
+  # Extract pid field — use jq if available, else grep+sed
+  if command -v jq &>/dev/null; then
+    RECORDED_PID=$(jq -r '.pid // empty' "$SESSIONS_DIR/$SID/meta.json" 2>/dev/null || true)
+  else
+    RECORDED_PID=$(grep -o '"pid"[[:space:]]*:[[:space:]]*"[^"]*"' "$SESSIONS_DIR/$SID/meta.json" \
+      | sed 's/.*"pid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | head -1)
+  fi
+
+  if [[ "$RECORDED_PID" == "$EXPECTED_PARENT_PID" ]]; then
+    # Verify the recorded PID is actually alive
+    if kill -0 "$RECORDED_PID" 2>/dev/null; then
+      pass "T9-ppid: meta.json.pid=$RECORDED_PID is live ancestor (kill -0 succeeds)"
+    else
+      fail "T9-ppid: meta.json.pid=$RECORDED_PID is set correctly but kill -0 failed (expected live)"
+    fi
+  else
+    fail "T9-ppid: meta.json.pid=$RECORDED_PID, expected $EXPECTED_PARENT_PID (the test process PID)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 TOTAL=$(( PASS + FAIL ))

--- a/plugins/coordinator/hooks/scripts/track-tier-usage.sh
+++ b/plugins/coordinator/hooks/scripts/track-tier-usage.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# PostToolUse hook: Count tool calls by investigation tier for the current session.
+#
+# Classifies each tool call into a context-loading tier per the tiered-context-loading
+# doctrine (docs/wiki/tiered-context-loading.md) and increments per-session counters
+# persisted to ~/.claude/projects/<project-slug>/tier-usage/<session_id>.json.
+#
+# Tier classification:
+#   tier 1 — Read of wiki/atlas/decisions/tracker paths
+#   tier 2 — mcp__*project-rag*__* call OR Bash invoking bin/query-records or bin/lint-frontmatter
+#   tier 3 — Read of any other path; Grep; Glob
+#   tier 4 — Agent dispatch (subagent_type captured; rationale_present detected)
+#   (other tools ignored — silent exit 0)
+#
+# Path portability: Python builds storage paths via os.path.expanduser, not bash $HOME,
+# to avoid the /c/Users/... vs C:\Users\... mismatch on Windows + Git Bash.
+#
+# Always exits 0 — advisory telemetry, never blocks tool execution.
+#
+# Input schema (PostToolUse):
+#   {
+#     "session_id": "<id>",
+#     "tool_name": "<name>",
+#     "tool_input": { ... },
+#     "cwd": "<path>"
+#   }
+
+# --- Safe stdin read ---
+if command -v timeout &>/dev/null; then
+  INPUT=$(timeout 2 cat 2>/dev/null || true)
+else
+  INPUT=$(cat)
+fi
+
+[[ -z "$INPUT" ]] && exit 0
+
+# ---------------------------------------------------------------------------
+# Extract fields using pure bash string operations (no external commands).
+# Pattern mirrors track-touched-files.sh for performance consistency.
+# ---------------------------------------------------------------------------
+
+# Extract tool_name
+if [[ "$INPUT" != *'"tool_name"'* ]]; then
+  exit 0
+fi
+_tmp="${INPUT#*\"tool_name\":\"}"
+TOOL_NAME="${_tmp%%\"*}"
+
+# Fast-exit: only classify relevant tools
+case "${TOOL_NAME:-}" in
+  Read|Grep|Glob|Bash|Agent) ;;         # classify these
+  mcp__*) ;;                             # mcp calls may be tier 2
+  *) exit 0 ;;
+esac
+
+# Extract session_id
+if [[ "$INPUT" != *'"session_id"'* ]]; then
+  exit 0
+fi
+_tmp="${INPUT#*\"session_id\":\"}"
+SESSION_ID="${_tmp%%\"*}"
+[[ -z "$SESSION_ID" ]] && exit 0
+
+# Extract cwd (for project slug)
+CWD=""
+if [[ "$INPUT" == *'"cwd"'* ]]; then
+  _tmp="${INPUT#*\"cwd\":\"}"
+  CWD="${_tmp%%\"*}"
+fi
+[[ -z "$CWD" ]] && CWD="$(pwd 2>/dev/null || echo "unknown")"
+
+# ---------------------------------------------------------------------------
+# Build project slug from cwd — matches coordinator-safe-commit convention.
+# Replace path separators with dashes; strip leading dash.
+# ---------------------------------------------------------------------------
+PROJECT_SLUG=$(echo "$CWD" | sed 's|[/\\]|-|g' | sed 's|^-||')
+[[ -z "$PROJECT_SLUG" ]] && PROJECT_SLUG="unknown"
+
+# ---------------------------------------------------------------------------
+# Tier classification logic.
+# ---------------------------------------------------------------------------
+TIER=""
+SUBAGENT_TYPE=""
+RATIONALE_PRESENT="false"
+
+# Tier 2: mcp__*project-rag*__* calls
+if [[ "$TOOL_NAME" == mcp__*project-rag*__* || "$TOOL_NAME" == mcp__*project_rag*__* ]]; then
+  TIER="tier2"
+fi
+
+# Classify by tool name (TIER not yet set)
+if [[ -z "$TIER" ]]; then
+  case "${TOOL_NAME}" in
+
+    Read)
+      # Extract file_path from tool_input
+      FILE_PATH=""
+      if [[ "$INPUT" == *'"file_path"'* ]]; then
+        _tmp="${INPUT#*\"file_path\":\"}"
+        FILE_PATH="${_tmp%%\"*}"
+      fi
+      # Tier 1 surfaces: wiki/, architecture-atlas/, decisions/, project-tracker.md,
+      # orientation_cache.md, lessons.md
+      if [[ "$FILE_PATH" == */docs/wiki/* || \
+            "$FILE_PATH" == */tasks/architecture-atlas/* || \
+            "$FILE_PATH" == */docs/decisions/* || \
+            "$FILE_PATH" == */docs/project-tracker.md || \
+            "$FILE_PATH" == *orientation_cache.md || \
+            "$FILE_PATH" == *lessons.md ]]; then
+        TIER="tier1"
+      else
+        TIER="tier3"
+      fi
+      ;;
+
+    Grep|Glob)
+      TIER="tier3"
+      ;;
+
+    Bash)
+      # Tier 2 if the command invokes bin/query-records or bin/lint-frontmatter
+      CMD=""
+      if [[ "$INPUT" == *'"command"'* ]]; then
+        _tmp="${INPUT#*\"command\":\"}"
+        CMD="${_tmp%%\"*}"
+      fi
+      if [[ "$CMD" == *bin/query-records* || "$CMD" == *bin/lint-frontmatter* ]]; then
+        TIER="tier2"
+      else
+        # Other Bash calls — not classified
+        exit 0
+      fi
+      ;;
+
+    Agent)
+      TIER="tier4"
+      # Extract subagent_type from tool_input
+      if [[ "$INPUT" == *'"subagent_type"'* ]]; then
+        _tmp="${INPUT#*\"subagent_type\":\"}"
+        SUBAGENT_TYPE="${_tmp%%\"*}"
+      fi
+      # Detect rationale preamble — heuristic substring match against the full INPUT JSON.
+      # Review: patrik R2 finding 5 — document the approximation rather than tighten with jq.
+      #
+      # Known edges:
+      #   False positive: if any tool_input field other than the prompt contains "tier 1-3 attempted"
+      #     (unlikely in practice — the phrase is only meaningful in a dispatch preamble).
+      #   False negative: if the phrase is JSON-escaped in an unusual way that breaks the substring.
+      #
+      # Deliberate choice: scanning the entire INPUT is cheap (no jq subprocess, no parse latency).
+      # Tightening to `jq -r '.tool_input.prompt'` would add a jq call to every Agent dispatch —
+      # not worth the cost for a heuristic telemetry counter. Revisit if false rates become a
+      # calibration problem.
+      PROMPT_LOWER=$(echo "$INPUT" | tr '[:upper:]' '[:lower:]' 2>/dev/null || echo "")
+      if [[ "$PROMPT_LOWER" == *"tier 1-3 attempted"* ]]; then
+        RATIONALE_PRESENT="true"
+      fi
+      ;;
+
+    *)
+      # Unclassified mcp__ or other tool — no tier
+      exit 0
+      ;;
+  esac
+fi
+
+[[ -z "$TIER" ]] && exit 0
+
+# ---------------------------------------------------------------------------
+# Persist counter to ~/.claude/projects/<slug>/tier-usage/<session_id>.json
+#
+# Pass values to Python via env vars rather than bash string interpolation to
+# avoid the /c/Users/... vs C:\Users\... path mismatch on Windows + Git Bash.
+# Python builds the storage path with os.path.expanduser, which resolves to
+# the correct native path on both POSIX and Windows.
+# ---------------------------------------------------------------------------
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+
+if command -v python3 &>/dev/null; then
+  TIER_SLUG="$PROJECT_SLUG" \
+  TIER_SESSION="$SESSION_ID" \
+  TIER_NAME="$TIER" \
+  TIER_NOW="$NOW" \
+  TIER_SUBAGENT="$SUBAGENT_TYPE" \
+  TIER_RATIONALE="$RATIONALE_PRESENT" \
+  python3 - <<'PYEOF' 2>/dev/null || exit 0
+import json, os
+
+project_slug      = os.environ.get("TIER_SLUG", "unknown")
+session_id        = os.environ.get("TIER_SESSION", "unknown")
+tier              = os.environ.get("TIER_NAME", "")
+now               = os.environ.get("TIER_NOW", "unknown")
+subagent_type     = os.environ.get("TIER_SUBAGENT", "")
+rationale_present = os.environ.get("TIER_RATIONALE", "false") == "true"
+
+# Build path via Python's own home resolution (works on Windows + POSIX)
+tier_dir  = os.path.join(os.path.expanduser("~"), ".claude", "projects", project_slug, "tier-usage")
+tier_file = os.path.join(tier_dir, session_id + ".json")
+
+os.makedirs(tier_dir, exist_ok=True)
+
+# Load existing or create fresh
+if os.path.exists(tier_file):
+    try:
+        with open(tier_file, "r") as f:
+            data = json.load(f)
+    except Exception:
+        data = {}
+else:
+    data = {}
+
+# Ensure shape
+data.setdefault("session_id", session_id)
+data.setdefault("started_at", now)
+data.setdefault("counts", {"tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0})
+for k in ("tier1", "tier2", "tier3", "tier4"):
+    data["counts"].setdefault(k, 0)
+data.setdefault("tier4_dispatches", [])
+
+# Increment
+if tier in data["counts"]:
+    data["counts"][tier] += 1
+
+# Record tier-4 dispatch detail
+if tier == "tier4":
+    data["tier4_dispatches"].append({
+        "ts": now,
+        "subagent_type": subagent_type,
+        "rationale_present": rationale_present
+    })
+
+# Write back
+with open(tier_file, "w") as f:
+    json.dump(data, f, indent=2)
+PYEOF
+else
+  # python3 unavailable — skip silently (telemetry is best-effort)
+  exit 0
+fi
+
+exit 0

--- a/plugins/coordinator/hooks/scripts/track-touched-files.sh
+++ b/plugins/coordinator/hooks/scripts/track-touched-files.sh
@@ -104,12 +104,43 @@ if [[ ! -d "$SESSION_DIR" ]]; then
     git rev-parse HEAD 2>/dev/null > "${SESSION_DIR}/head_at_start" || echo "unknown" > "${SESSION_DIR}/head_at_start"
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     printf '{"session_id":"%s","branch":"%s","pid":"%s","last_activity":"%s","goal":""}\n' \
-      "$SESSION_ID" "$BRANCH" "$$" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "${SESSION_DIR}/meta.json"
+      "$SESSION_ID" "$BRANCH" "$PPID" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "${SESSION_DIR}/meta.json"
   fi
 fi
 
 # Ensure touched.txt exists
 [[ -f "$TOUCHED_FILE" ]] || touch "$TOUCHED_FILE"
+
+# ---------------------------------------------------------------------------
+# W1.0b: Record live $PPID in meta.json so PPID-walk has a live ancestor.
+#
+# cs_init writes $$ (the hook subprocess PID) which is dead by the time
+# coordinator-safe-commit runs. $PPID here is the Bash-tool shell that spawned
+# this hook — a live ancestor that IS on the helper's process chain.
+#
+# Atomic write: write to a tempfile then mv-rename to avoid partial-read races.
+# Uses jq --arg to avoid filter-injection (unlike the pre-existing
+# ".${field}" patterns in coordinator-session.sh:104,119 slated for W6).
+# Falls back to sed if jq is unavailable.
+# ---------------------------------------------------------------------------
+_META_JSON="${SESSION_DIR}/meta.json"
+if [[ -f "$_META_JSON" ]]; then
+  _LIVE_PID="$PPID"
+  _META_TMP="${_META_JSON}.pid.$$"
+  if command -v jq &>/dev/null; then
+    if jq --arg p "$_LIVE_PID" '.pid = $p' "$_META_JSON" > "$_META_TMP" 2>/dev/null; then
+      mv -f "$_META_TMP" "$_META_JSON" 2>/dev/null || rm -f "$_META_TMP"
+    else
+      rm -f "$_META_TMP"
+    fi
+  else
+    # sed fallback — replaces the first "pid" string value in meta.json
+    sed "s/\"pid\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"pid\": \"${_LIVE_PID}\"/" \
+      "$_META_JSON" > "$_META_TMP" 2>/dev/null \
+      && mv -f "$_META_TMP" "$_META_JSON" 2>/dev/null \
+      || rm -f "$_META_TMP"
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Normalize file_path to repo-relative.

--- a/plugins/coordinator/hooks/scripts/validate-frontmatter-schema.js
+++ b/plugins/coordinator/hooks/scripts/validate-frontmatter-schema.js
@@ -1,0 +1,260 @@
+'use strict';
+/**
+ * validate-frontmatter-schema.js — PreToolUse hook that surfaces frontmatter-schema
+ * violations to the agent before a Write/Edit/MultiEdit lands on a tracked-record file.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W1/Validator
+ *
+ * Default mode is WARN: emits the violation as additionalContext so the agent sees
+ * the schema gripe but the write still proceeds. Strict mode (COORDINATOR_SCHEMA_STRICT=1)
+ * restores the original deny behavior — the write is blocked. Periodic drift sweeps
+ * via bin/query-records --validate-all (in /update-docs) catch accumulated warn-mode drift.
+ *
+ * Reads Claude PreToolUse JSON from stdin. Exits 0 in all cases (hook contract).
+ *
+ * Negative-spec: this hook NEVER exits non-zero. Infra failures (schema load, repo
+ * root resolution, file read) are logged to stderr and silently allowed — never block
+ * on infra. The hook double-fails intentionally on Edit mismatches by falling through
+ * silent (let Edit fail on its own merits per Patrik R1 finding 0).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { loadSchemas, matchSchemaForPath, parseFrontmatter, validateFrontmatter, validateLessonsFile } = require('../../bin/lib/schema.js');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SCHEMAS_DIR = path.join(__dirname, '../../schemas');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the git repo root by running `git rev-parse --show-toplevel` in cwd.
+ * Falls back to cwd if the command fails or we're not in a git repo.
+ */
+function resolveRepoRoot(cwd) {
+  try {
+    const result = execSync('git rev-parse --show-toplevel', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 3000,
+    });
+    return result.trim();
+  } catch {
+    return cwd;
+  }
+}
+
+/**
+ * Convert an absolute file_path to a repo-relative path using forward slashes.
+ * Returns null if the path is not under repoRoot.
+ */
+function toRepoRelative(absPath, repoRoot) {
+  const normalAbs = absPath.replace(/\\/g, '/');
+  const normalRoot = repoRoot.replace(/\\/g, '/');
+  if (!normalAbs.startsWith(normalRoot)) return null;
+  return normalAbs.slice(normalRoot.length).replace(/^\//, '');
+}
+
+/**
+ * Apply a single old_string→new_string replacement to content.
+ * Returns { result: string, matched: boolean }.
+ */
+function applyEdit(content, oldString, newString) {
+  const idx = content.indexOf(oldString);
+  if (idx === -1) return { result: content, matched: false };
+  return {
+    result: content.slice(0, idx) + newString + content.slice(idx + oldString.length),
+    matched: true,
+  };
+}
+
+/**
+ * Build a hook output payload for a validation failure.
+ * errors is an array of {field, error, hint} (or {line, field, error, hint} for lessons).
+ *
+ * Default mode (warn): emits additionalContext — the agent sees the message, write proceeds.
+ * Strict mode (COORDINATOR_SCHEMA_STRICT=1): emits a deny — the write is blocked.
+ */
+function buildViolationPayload(schemaName, errors) {
+  const parts = errors.map(e => {
+    const field = e.field || '(unknown)';
+    const hint = e.hint ? `; required shape: ${e.hint}` : '';
+    return `${field}: ${e.error}${hint}`;
+  });
+  const message = `${schemaName}: ${parts.join('; ')}`;
+  const strict = process.env.COORDINATOR_SCHEMA_STRICT === '1';
+
+  if (strict) {
+    return JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: message,
+      },
+    });
+  }
+
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: `[frontmatter-schema warning] ${message}\n\nThe write will proceed. Fix the frontmatter on the next edit, or set COORDINATOR_SCHEMA_STRICT=1 to block on violations. Periodic drift is swept by /update-docs.`,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Read all stdin
+  let raw = '';
+  try {
+    for await (const chunk of process.stdin) {
+      raw += chunk;
+    }
+  } catch {
+    process.exit(0);
+  }
+
+  // Parse PreToolUse payload
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = payload.tool_name;
+  const toolInput = payload.tool_input || {};
+  const cwd = payload.cwd || process.cwd();
+
+  const filePath = toolInput.file_path;
+  if (!filePath) process.exit(0);
+
+  // Resolve repo root and repo-relative path
+  const repoRoot = resolveRepoRoot(cwd);
+  const absFilePath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  const repoRel = toRepoRelative(absFilePath, repoRoot);
+  if (!repoRel) process.exit(0);
+
+  // Load schemas (telemetry-style: log to stderr on error, never block)
+  let schemas;
+  try {
+    schemas = loadSchemas(SCHEMAS_DIR);
+  } catch (err) {
+    process.stderr.write(`validate-frontmatter-schema: schema load error: ${err.message}\n`);
+    process.exit(0);
+  }
+
+  // Match schema for this path
+  const match = matchSchemaForPath(repoRel, schemas);
+  if (!match) process.exit(0); // not a tracked-record path
+
+  const { schemaName, schema } = match;
+
+  // Build prospective content based on tool type
+  let prospectiveContent;
+
+  if (toolName === 'Write') {
+    // Write: use content directly
+    prospectiveContent = toolInput.content || '';
+
+  } else if (toolName === 'Edit') {
+    const oldString = toolInput.old_string;
+    const newString = toolInput.new_string;
+
+    // Read current file if it exists
+    let current;
+    try {
+      current = fs.readFileSync(absFilePath, 'utf8');
+    } catch {
+      // File doesn't exist — old_string can't match; fall through silent.
+      // (Edit will fail on its own merits when Claude applies it.)
+      process.exit(0);
+    }
+
+    // Apply the edit
+    const { result, matched } = applyEdit(current, oldString || '', newString || '');
+    if (!matched) {
+      // old_string doesn't appear — fall through silent (let Edit fail on its own)
+      process.exit(0);
+    }
+    prospectiveContent = result;
+
+  } else if (toolName === 'MultiEdit') {
+    const edits = toolInput.edits || [];
+
+    // Read current file if it exists
+    let current = '';
+    try {
+      current = fs.readFileSync(absFilePath, 'utf8');
+    } catch {
+      // File doesn't exist — start with empty
+      current = '';
+    }
+
+    // Apply each edit sequentially
+    let content = current;
+    for (const edit of edits) {
+      const { result, matched } = applyEdit(content, edit.old_string || '', edit.new_string || '');
+      if (!matched) {
+        // Any mismatch — fall through silent
+        process.exit(0);
+      }
+      content = result;
+    }
+    prospectiveContent = content;
+
+  } else {
+    process.exit(0);
+  }
+
+  // Validate the prospective content against the schema
+  let validationResult;
+
+  if (schema.match_mode === 'inline-tag-per-entry') {
+    // Lessons file — validate inline tags
+    validationResult = validateLessonsFile(prospectiveContent, schema);
+  } else {
+    // Standard frontmatter validation
+    const { frontmatter } = parseFrontmatter(prospectiveContent);
+
+    // Missing frontmatter on a schema'd file → surface as warn (or deny under strict mode)
+    if (frontmatter === null) {
+      const requiredFields = schema.required ? Object.keys(schema.required) : [];
+      const hint = requiredFields.length > 0
+        ? `expected fields: ${requiredFields.join(', ')}`
+        : 'add --- delimited YAML frontmatter';
+      process.stdout.write(buildViolationPayload(schemaName, [{
+        field: '(missing frontmatter)',
+        error: 'no YAML frontmatter found',
+        hint,
+      }]));
+      process.exit(0);
+    }
+
+    validationResult = validateFrontmatter(frontmatter, schema);
+  }
+
+  if (validationResult.ok) {
+    // Pass — exit silent
+    process.exit(0);
+  }
+
+  // Fail — emit warn (or deny under COORDINATOR_SCHEMA_STRICT=1) to stdout
+  process.stdout.write(buildViolationPayload(schemaName, validationResult.errors));
+  process.exit(0);
+}
+
+main().catch(err => {
+  process.stderr.write(`validate-frontmatter-schema: unexpected error: ${err.message}\n`);
+  process.exit(0);
+});

--- a/plugins/coordinator/hooks/scripts/validate-frontmatter-schema.test.js
+++ b/plugins/coordinator/hooks/scripts/validate-frontmatter-schema.test.js
@@ -1,0 +1,310 @@
+'use strict';
+/**
+ * validate-frontmatter-schema.test.js — integration tests for the PreToolUse
+ * frontmatter validator hook.
+ *
+ * Spec backlink: docs/plans/2026-05-01-portable-ideas-from-obsidian-research.md §W1/Validator/Tests
+ *
+ * Each test spawns the hook script as a subprocess with stdin piped JSON and
+ * asserts stdout / exit code. This mirrors exactly how the Claude runtime
+ * invokes the hook, making these true end-to-end integration tests.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HOOK_SCRIPT = path.join(__dirname, 'validate-frontmatter-schema.js');
+
+/**
+ * Spawn the hook with the given payload (object → JSON string piped to stdin).
+ * Returns { stdout, stderr, exitCode }.
+ */
+function runHook(payload) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [HOOK_SCRIPT], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', d => { stdout += d.toString(); });
+    child.stderr.on('data', d => { stderr += d.toString(); });
+
+    child.on('close', exitCode => resolve({ stdout, stderr, exitCode }));
+    child.on('error', reject);
+
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+/**
+ * Create a temp directory (auto-cleaned at process exit).
+ * Returns the directory path.
+ */
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fmhook-test-'));
+}
+
+/**
+ * Build a minimal Write payload.
+ */
+function writePayload(filePath, content, cwd) {
+  return {
+    tool_name: 'Write',
+    tool_input: { file_path: filePath, content },
+    session_id: 'test-session',
+    cwd: cwd || os.tmpdir(),
+  };
+}
+
+/**
+ * Build a minimal Edit payload.
+ */
+function editPayload(filePath, oldString, newString, cwd) {
+  return {
+    tool_name: 'Edit',
+    tool_input: { file_path: filePath, old_string: oldString, new_string: newString },
+    session_id: 'test-session',
+    cwd: cwd || os.tmpdir(),
+  };
+}
+
+// The schemas dir lives relative to this file
+const SCHEMAS_DIR = path.join(__dirname, '../../schemas');
+
+// We need a real repo root so the hook can match repoRelative paths.
+// hooks/scripts/ is 5 levels below ~/.claude:
+//   ~/.claude/plugins/coordinator-claude/coordinator/hooks/scripts
+// so ../../../../../ resolves to ~/.claude.
+const CLAUDE_ROOT = path.resolve(__dirname, '../../../../../');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('validate-frontmatter-schema hook', () => {
+
+  // -------------------------------------------------------------------------
+  // Allow: valid handoff Write content passes
+  // -------------------------------------------------------------------------
+  test('Allow — valid handoff Write', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'tasks', 'handoffs', 'test-valid.md');
+    const content = [
+      '---',
+      'title: Test Handoff',
+      'created: 2026-05-01',
+      'branch: work/57754134/2026-05-01',
+      'status: active',
+      'predecessor: null',
+      '---',
+      '# Body',
+    ].join('\n');
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.equal(stdout, '', 'should emit no JSON on pass');
+  });
+
+  // -------------------------------------------------------------------------
+  // Block (Write): missing required field 'branch'
+  // -------------------------------------------------------------------------
+  test('Block (Write) — handoff missing branch field', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'tasks', 'handoffs', 'test-missing-branch.md');
+    const content = [
+      '---',
+      'title: Test Handoff',
+      'created: 2026-05-01',
+      'status: active',
+      'predecessor: null',
+      '---',
+      '# Body',
+    ].join('\n');
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.ok(stdout.length > 0, 'should emit deny JSON');
+
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(
+      parsed.hookSpecificOutput.permissionDecisionReason.includes('branch'),
+      `reason should mention "branch", got: ${parsed.hookSpecificOutput.permissionDecisionReason}`
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Block (Write): plan with invalid status enum
+  // -------------------------------------------------------------------------
+  test('Block (Write) — plan with invalid status enum', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'docs', 'plans', 'test-bad-status.md');
+    const content = [
+      '---',
+      'title: Some Plan',
+      'created: 2026-05-01',
+      'author: EM',
+      'status: invented',
+      '---',
+      '# Plan',
+    ].join('\n');
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.ok(stdout.length > 0, 'should emit deny JSON');
+
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    // Reason should mention the enum values
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    assert.ok(
+      reason.includes('draft') || reason.includes('approved') || reason.includes('enum'),
+      `reason should mention enum values or "enum", got: ${reason}`
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Allow: Write to non-schema'd wiki path
+  // -------------------------------------------------------------------------
+  test('Allow — Write to non-schema\'d wiki path', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'docs', 'wiki', 'some-guide.md');
+    const content = '# A wiki guide\n\nNo frontmatter required here.';
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.equal(stdout, '', 'should emit no JSON for non-schema\'d path');
+  });
+
+  // -------------------------------------------------------------------------
+  // Allow: Edit with old_string not matching the existing file → fall through
+  // -------------------------------------------------------------------------
+  test('Allow — Edit with old_string mismatch falls through silent', async () => {
+    // Point at a non-existent handoff file under CLAUDE_ROOT so path matching picks up
+    // the handoff schema. Since the file doesn't exist, current content is '', and
+    // old_string won't match '' → fall-through silent (let Edit fail on its own merits).
+    const filePath = path.join(CLAUDE_ROOT, 'tasks', 'handoffs', 'nonexistent-mismatch.md');
+    const payload = editPayload(
+      filePath,
+      'THIS STRING DOES NOT EXIST IN ANY FILE',
+      'replacement',
+      CLAUDE_ROOT
+    );
+
+    const { stdout, exitCode } = await runHook(payload);
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.equal(stdout, '', 'should emit no JSON on mismatch fall-through');
+  });
+
+  // -------------------------------------------------------------------------
+  // Block: missing frontmatter on a schema'd file
+  // -------------------------------------------------------------------------
+  test('Block — missing frontmatter on schema\'d handoff path', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'tasks', 'handoffs', 'test-no-fm.md');
+    const content = '# No frontmatter here at all\n\nJust regular markdown.';
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.ok(stdout.length > 0, 'should emit deny JSON');
+
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    assert.ok(
+      reason.toLowerCase().includes('frontmatter') || reason.includes('title') || reason.includes('branch'),
+      `reason should mention missing frontmatter or required fields, got: ${reason}`
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Smoke (lessons): valid + invalid tag entry → deny on bad tag
+  // -------------------------------------------------------------------------
+  test('Smoke (lessons) — invalid tag entry triggers deny', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'tasks', 'lessons.md');
+    const content = [
+      '# Lessons',
+      '',
+      '- **Good Lesson [universal]** — This is fine.',
+      '  Always do the right thing.',
+      '',
+      '- **Bad Lesson [whatever]** — This tag is not in the allowed list.',
+      '  Some detail here.',
+    ].join('\n');
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.ok(stdout.length > 0, 'should emit deny JSON for bad tag');
+
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    assert.ok(
+      reason.includes('whatever'),
+      `reason should mention the bad tag "whatever", got: ${reason}`
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Allow: lessons file with only valid tags
+  // -------------------------------------------------------------------------
+  test('Allow — lessons file with only valid [universal] tags', async () => {
+    const filePath = path.join(CLAUDE_ROOT, 'tasks', 'lessons.md');
+    const content = [
+      '# Lessons',
+      '',
+      '- **Good Lesson [universal]** — This is universally applicable.',
+      '  Always do the right thing.',
+      '',
+      '- **Project Lesson [project]** — Project-specific note.',
+      '  Some detail.',
+      '',
+      '- **Untagged Lesson** — No tag, which is allowed.',
+    ].join('\n');
+
+    const { stdout, exitCode } = await runHook(writePayload(filePath, content, CLAUDE_ROOT));
+    assert.equal(exitCode, 0, 'should exit 0');
+    assert.equal(stdout, '', 'should emit no JSON for valid lessons');
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge: malformed JSON stdin → silent exit 0
+  // -------------------------------------------------------------------------
+  test('Edge — malformed JSON stdin exits 0 silent', async () => {
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [HOOK_SCRIPT], { stdio: ['pipe', 'pipe', 'pipe'] });
+      let stdout = '';
+      child.stdout.on('data', d => { stdout += d.toString(); });
+      child.on('close', exitCode => resolve({ stdout, exitCode }));
+      child.on('error', reject);
+      child.stdin.write('NOT JSON {{{');
+      child.stdin.end();
+    });
+
+    assert.equal(result.exitCode, 0, 'should exit 0 on malformed input');
+    assert.equal(result.stdout, '', 'should emit nothing on malformed input');
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge: missing file_path → silent exit 0
+  // -------------------------------------------------------------------------
+  test('Edge — missing file_path exits 0 silent', async () => {
+    const payload = {
+      tool_name: 'Write',
+      tool_input: { content: '# hello' },
+      session_id: 'test',
+      cwd: CLAUDE_ROOT,
+    };
+
+    const { stdout, exitCode } = await runHook(payload);
+    assert.equal(exitCode, 0);
+    assert.equal(stdout, '');
+  });
+
+});

--- a/plugins/coordinator/lib/coordinator-session.sh
+++ b/plugins/coordinator/lib/coordinator-session.sh
@@ -89,7 +89,7 @@ _cs_iso_to_epoch() {
   local epoch
   epoch=$(date -u -d "$iso" +%s 2>/dev/null) \
     || epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) \
-    || epoch=$(python3 -c "import datetime; print(int(datetime.datetime.fromisoformat('${iso%Z}').replace(tzinfo=datetime.timezone.utc).timestamp()))" 2>/dev/null) \
+    || epoch=$(python3 -c 'import sys, datetime; iso=sys.argv[1]; iso = iso[:-1] if iso.endswith("Z") else iso; print(int(datetime.datetime.fromisoformat(iso).replace(tzinfo=datetime.timezone.utc).timestamp()))' "$iso" 2>/dev/null) \
     || epoch=0
   echo "$epoch"
 }
@@ -101,8 +101,15 @@ _cs_read_meta_field() {
   local meta="${sdir}/meta.json"
   [[ -f "$meta" ]] || { echo ""; return; }
   if command -v jq &>/dev/null; then
-    jq -r ".${field} // empty" "$meta" 2>/dev/null || true
+    # W6.2: pass field via --arg to jq (no shell interpolation into jq filter).
+    jq --arg f "$field" -r '.[$f] // empty' "$meta" 2>/dev/null || true
   else
+    # W6.4: sed fallback — used only when jq is unavailable. The regex
+    # interpolates ${field} into the pattern; callers MUST ensure $field is a
+    # safe identifier (matching ^[a-zA-Z_][a-zA-Z0-9_]*$). The internal API
+    # only uses literal field names ("pid", "started_at"), never user input.
+    # If a future caller passes user-controlled field names, switch to a
+    # python/awk fallback or hard-fail.
     sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$meta" | head -1
   fi
 }
@@ -115,10 +122,16 @@ _cs_update_meta_field() {
   local meta="${sdir}/meta.json"
   [[ -f "$meta" ]] || return 1
   if command -v jq &>/dev/null; then
+    # W6.3: pass both field and value via --arg (no shell interpolation into jq filter).
     local tmp
-    tmp=$(jq --arg v "$value" ".${field} = \$v" "$meta" 2>/dev/null) && echo "$tmp" > "$meta"
+    tmp=$(jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$meta" 2>/dev/null) && echo "$tmp" > "$meta"
   else
-    # sed in-place fallback — replaces the first occurrence of "field": "..."
+    # W6.4: sed in-place fallback — used only when jq is unavailable. ${field}
+    # and ${value} are interpolated into the regex/replacement; callers MUST
+    # ensure neither contains regex metacharacters or sed delimiter characters.
+    # The internal API only writes literal field names + sanitized session
+    # values (PIDs, ISO timestamps), never user input. If a future caller
+    # passes user-controlled values, switch to a python/awk fallback.
     sed -i "s/\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"${field}\": \"${value}\"/" "$meta" 2>/dev/null || true
   fi
 }
@@ -177,6 +190,47 @@ cs_init() {
   "goal": "${goal}"
 }
 METAJSON
+  fi
+
+  return 0
+}
+
+# cs_write_sentinel <session_id>
+#   Atomically write the sentinel file (.current-session-id) so readers never
+#   observe a partial write. Uses tempfile + mv -f (rename is atomic on most
+#   POSIX filesystems). On Windows + Git Bash, antivirus may lock the sentinel
+#   target during the rename window; in that case, fall back to a direct write
+#   and emit a warning so the caller can log the degraded-atomicity path.
+#
+#   W1.4 spec backlink: plan — atomic sentinel writes with locked-file fallback.
+#
+#   Returns 0 on success (including the fallback path). Returns 1 only if the
+#   sessions directory cannot be determined (no git repo).
+cs_write_sentinel() {
+  local sid="${1:?session_id required}"
+  local base
+  base=$(_cs_sessions_dir) || return 1
+
+  local sentinel="${base}/.current-session-id"
+  local tmp="${base}/.current-session-id.${$}"
+
+  # Ensure sessions dir exists
+  mkdir -p "$base"
+
+  # Write to tempfile first, then rename for atomicity
+  if printf '%s\n' "$sid" > "$tmp" 2>/dev/null; then
+    if mv -f "$tmp" "$sentinel" 2>/dev/null; then
+      return 0
+    else
+      # mv failed — likely AV locking on Windows + Git Bash
+      rm -f "$tmp" 2>/dev/null || true
+      echo "[coordinator-session] WARN: sentinel rename failed (target may be AV-locked); used direct write — partial-read race possible" >&2
+      printf '%s\n' "$sid" > "$sentinel" 2>/dev/null || return 0
+    fi
+  else
+    # tempfile write failed — fall back to direct write
+    echo "[coordinator-session] WARN: sentinel rename failed (target may be AV-locked); used direct write — partial-read race possible" >&2
+    printf '%s\n' "$sid" > "$sentinel" 2>/dev/null || return 0
   fi
 
   return 0
@@ -324,15 +378,31 @@ cs_compute_scope() {
   fi
 
   # --- Step 4: Apply subtraction and emit MY_SCOPE ---
+  # W3 (Patrik R1 finding #1): distinguish "another session owns this" from
+  # "stale self-claim" when CLAUDE_SESSION_ID is set but resolution diverged.
+  # Append "(your session=<resolved>)" for disambiguation in the normal case.
   local my_scope=()
+  local env_sid="${CLAUDE_SESSION_ID:-}"
+  local excluded_count=0
   for candidate in "${touched_set[@]:-}"; do
     [[ -z "$candidate" ]] && continue
     if [[ -v "other_claims[$candidate]" ]]; then
-      echo "skipping ${candidate} — owned by session ${other_claims[$candidate]}" >&2
+      local claim_sid="${other_claims[$candidate]}"
+      if [[ -n "$env_sid" && "$claim_sid" == "$env_sid" ]]; then
+        echo "skipping ${candidate} — stale self-claim from this session (resolved=${sid}, env=${env_sid}) — investigate session ID resolution" >&2
+      else
+        echo "skipping ${candidate} — owned by session ${claim_sid} (your session=${sid})" >&2
+      fi
+      (( excluded_count++ )) || true
     else
       my_scope+=("$candidate")
     fi
   done
+
+  # W3 epilogue: when ≥1 file was excluded, point the user at the right diagnostic.
+  if (( excluded_count > 0 )); then
+    echo "  hint: if your files are being skipped as 'owned by another session' but you wrote them, your session ID resolution is wrong (see ~/.claude/docs/wiki/scoped-safety-commits.md troubleshooting)" >&2
+  fi
 
   # --- Step 5: Orphan detection ---
   for dfile in "${dirty_files[@]:-}"; do

--- a/plugins/coordinator/lib/tests/test-coordinator-session.sh
+++ b/plugins/coordinator/lib/tests/test-coordinator-session.sh
@@ -419,6 +419,80 @@ assert_dir_exists   "T15b live session dir still present" "${REPO}/.git/coordina
 echo
 
 # ---------------------------------------------------------------------------
+# T16: cs_write_sentinel — atomic write creates sentinel
+# W1.4 spec backlink: atomic sentinel write (temp + rename).
+# ---------------------------------------------------------------------------
+echo "--- T16: cs_write_sentinel atomic write ---"
+
+SID_SENT="test-session-sentinel"
+cs_init "$SID_SENT"
+
+cs_write_sentinel "$SID_SENT"
+SENTINEL_PATH="${REPO}/.git/coordinator-sessions/.current-session-id"
+
+assert_file_exists "T16a sentinel file created" "$SENTINEL_PATH"
+
+SENTINEL_VAL=$(cat "$SENTINEL_PATH" | tr -d '[:space:]')
+assert_eq "T16b sentinel contains correct session ID" "$SENTINEL_VAL" "$SID_SENT"
+
+echo
+
+# ---------------------------------------------------------------------------
+# T17: cs_write_sentinel — overwrites existing sentinel atomically
+# Verifies that a second call updates the sentinel value.
+# W1.4 spec backlink: atomic sentinel write idempotent / overwrite.
+# ---------------------------------------------------------------------------
+echo "--- T17: cs_write_sentinel overwrites existing sentinel ---"
+
+SID_SENT2="test-session-sentinel-2"
+cs_init "$SID_SENT2"
+
+cs_write_sentinel "$SID_SENT2"
+SENTINEL_VAL2=$(cat "$SENTINEL_PATH" | tr -d '[:space:]')
+assert_eq "T17a sentinel updated to second session" "$SENTINEL_VAL2" "$SID_SENT2"
+
+echo
+
+# ---------------------------------------------------------------------------
+# T18: cs_write_sentinel — locked-target fallback emits warning, still writes
+# Simulates AV-locking by making the tempfile location unwritable, then verifying
+# the fallback direct-write path fires and emits the expected warning text.
+# W1.4 spec backlink: locked-target fallback with warning emission.
+# ---------------------------------------------------------------------------
+echo "--- T18: cs_write_sentinel locked-target fallback ---"
+
+SID_SENT3="test-session-sentinel-3"
+cs_init "$SID_SENT3"
+
+# Simulate locked-target by making sessions dir read-only for the mv step.
+# Strategy: create a sessions dir subdir that will block tempfile creation
+# within that dir, by pointing the sentinel at a path where mkdir -p already
+# created the dir as a file (not a dir) — this forces the tempfile write to fail.
+# Simpler approach: chmod the sessions dir temporarily to block file creation.
+# On Git Bash (Windows) chmod -w may not prevent writes, so we test portably:
+# we verify that the function still produces the sentinel value even via fallback.
+
+# Direct fallback test: write a read-only sentinel, verify cs_write_sentinel
+# can still update it (either via mv or direct write).
+chmod 444 "$SENTINEL_PATH" 2>/dev/null || true
+SENTINEL_WARN=$(cs_write_sentinel "$SID_SENT3" 2>&1 || true)
+chmod 644 "$SENTINEL_PATH" 2>/dev/null || true
+
+# The sentinel may or may not be writable depending on filesystem/OS.
+# What we CAN reliably test: if mv failed, the WARN message was emitted,
+# OR if it succeeded silently, the value is correct.
+SENTINEL_AFTER=$(cat "$SENTINEL_PATH" 2>/dev/null | tr -d '[:space:]' || true)
+if [[ "$SENTINEL_AFTER" == "$SID_SENT3" ]]; then
+  _pass "T18a sentinel written (atomic or fallback)"
+elif echo "$SENTINEL_WARN" | grep -q "WARN"; then
+  _pass "T18a fallback warning emitted when write failed (expected on read-only FS)"
+else
+  _fail "T18a sentinel not written and no fallback warning (unexpected failure)"
+fi
+
+echo
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo "==================================="

--- a/plugins/coordinator/pipelines/mise-en-place/PIPELINE.md
+++ b/plugins/coordinator/pipelines/mise-en-place/PIPELINE.md
@@ -25,35 +25,62 @@ The tail action after execution depends on how the PM invoked the skill:
 
 **Announce at start:** "I'm running `/mise-en-place` to prep and execute a straight shot through the backlog."
 
+## What Mise IS NOT
+
+Mise is not "plan-as-you-go autonomy." It is not a license to live-assemble specs, research contracts that downstream items will consume, or run a "foundations wave" whose output becomes reference material for later waves. Those activities require EM judgment, reviewer dispatch, and PM alignment — they are session-EM territory, not autonomous-execution territory.
+
+The coordinator system optimizes for first-pass correctness: planning happens deeply BEFORE the run, so executors only type. If a planned wave produces decisions/artifacts that later waves depend on for their own definition, the run is not ready for mise — it is ready for a planning session.
+
 ## When to Use
 
-- You have 2+ thoroughly-scoped work items ready for execution (plan stubs, enriched specs, well-defined tasks)
-- The items are sequentially executable — each can be completed before moving to the next
-- The PM wants autonomous execution with minimal interruption
+- You have 2+ items that are **mise-grade** by the readiness criteria below
+- The PM wants autonomous execution of mechanical work with minimal interruption
 - The PM wants the backlog cleared — whether they're watching, stepping away, or wrapping up for the day
 
-**Don't use when:**
-- Items aren't scoped yet — use `coordinator:writing-plans` or `coordinator:brainstorming` first
-- Only one item to execute — use `/execute-plan` directly
-- The work requires iterative PM judgment calls throughout
+## Readiness Criteria — All Items Must Pass
+
+A mise-grade item meets ALL of the following:
+
+1. **Reviewed and sealed.** Spec has been through enrichment + reviewer; findings integrated. No "executor types it, then we review."
+2. **No downstream contract.** Output is not reference material later waves consume to define their own behavior.
+3. **Pure-executor agent type.** A Sonnet executor (or coordinator-inline) can complete it given the spec — not enricher, not reviewer, not staff-session, not live-MCP authoring.
+4. **File footprint declarable.** Files-to-be-written can be named in advance.
+5. **Verification is mechanical.** Tests pass, signatures match, AC checked off — not "the reviewer agrees."
+
+## Don't Use When
+
+The EM must REJECT a /mise run if any candidate item exhibits these patterns:
+
+- **"Wave 1: foundations"** — wiki pages, contract definitions, schema authoring, research outputs, or any artifact later waves consume as reference. Foundations belong in a planning session, not a mise.
+- **Mixed agent types in the planned waves** — enricher + executor + MCP-author together signals the work isn't ready.
+- Items marked `Pending Review` or with open reviewer findings.
+- Vague acceptance criteria ("improves the system") rather than verifiable ones.
+- Items requiring `manage_*` MCP tools in a live editor — those need an interactive EM-driven flow.
+- Research/brainstorming stubs whose output is "a decision."
+- Only one item — use `/execute-plan` directly.
+- Items aren't scoped yet — use `coordinator:writing-plans` or `coordinator:brainstorming` first.
+- Iterative PM judgment expected throughout.
+
+**If even one item fails, decline the entire run** rather than fragmenting it on the fly. Output a clear refusal naming each disqualifying item, the reason, and the recommended next step (planning session, /enrich-and-review, /review-dispatch, /staff-session, /delegate-execution). The PM decides whether to pull the failed items or defer the mise.
 
 ## The Process
 
+### Phase 0: Readiness Gate
+
+**Bypass condition.** If the session was opened from a handoff (or the PM's invocation explicitly references one) and that handoff states the queued items have already been gated as mise-ready, **skip Phase 0 entirely** and proceed to Phase 1. The bypass is valid when the handoff names the items in scope and asserts mise-readiness in unambiguous terms. Re-running the gate after a verified handoff is wasted context — large backlogs can blow the EM's window on stub reading alone, which is the failure mode this bypass exists to prevent. Announce the bypass: "Phase 0 bypassed — handoff at <path> verified mise-readiness for [items]." If unsure whether the handoff covers all queued items, do NOT bypass.
+
+**Otherwise:** before inventory, before announcement, before any flight-recorder work — apply the readiness criteria above to every candidate item. If any item fails, output the refusal block (see the command file for format) and stop. Do not proceed to Phase 1.
+
 ### Phase 1: Inventory — What's on the Board?
 
-Gather every ready-to-execute work item. Sources to check:
+**Bandwidth rule:** The EM does NOT read every stub. For runs with >3 items (or PM-flagged "many items"), dispatch a Sonnet inventory scout with `run_in_background: true` to produce a structured table at `tasks/mise-inventory-<timestamp>.md` (one row per item: identifier | spec path | one-line summary | declared file footprint | dependencies | verification | complexity). The scout writes to disk and returns `DONE: <path>`; the EM reads the table from disk and works from it for Phase 2 sequencing. The full spec text stays out of the EM's context until the executors load it.
+
+Sources the scout (or the EM, for ≤3-item runs) checks:
 
 1. **Plan files:** `tasks/*/todo.md` — items marked ready/pending execution
 2. **Enriched stubs:** Any chunk directories with status "Enriched" or "Reviewed"
 3. **PM's explicit list:** If the PM named specific items (e.g., "PX4-6B through Cesium-D"), use that as the canonical list
 4. **Open tasks:** Any `tasks/*/` directories with incomplete work
-
-For each item, capture:
-- **Identifier** (stub name, plan reference, or short description)
-- **Location** (file path to spec/plan)
-- **Dependencies** (does it need another item completed first?)
-- **Estimated complexity** (quick read of the spec — small/medium/large)
-- **Verification method** (how will you know it's done?)
 
 ### Phase 2: Sequence and Parallelize — Maximum Velocity
 
@@ -137,18 +164,20 @@ This tells the hook to emit informational-only context pressure messages (no han
 
 **Execute wave by wave.** Each wave from Phase 2 is a batch of file-disjoint items:
 
+**Bandwidth rule:** /mise backgrounds executors by default — single-item waves included. The EM steers many items; pulling each executor's transcript into context burns the window before the run finishes. Executors do their own verification-and-commit; verifiers (Haiku, also backgrounded) check the result; the EM reads only one-screen DONE summaries and PASS/FAIL verdicts from disk.
+
 **For each wave:**
 
 1. **Dispatch all items in the wave concurrently.** For each item:
    - Mark `in_progress` via TaskUpdate. Update plan document status if applicable.
-   - Dispatch to a Sonnet executor agent with `run_in_background: true`. The prompt must include: the full spec (or path to it), the item's file footprint from Phase 2, and an explicit constraint: *"You MUST NOT create or modify any file outside this footprint: [list]. If you discover you need to, STOP and report back."*
-   - Items that benefit from accumulated coordinator context (coherence decisions, cross-file awareness) stay in-coordinator and execute sequentially within the wave.
+   - Dispatch to a Sonnet executor agent with `run_in_background: true` and `mode: "acceptEdits"`. The prompt must include the full spec (or path to it), the item's file footprint from Phase 2, the footprint constraint, the self-verify-and-commit constraint, and the DONE-summary constraint. See the command file for verbatim wording.
+   - Items that benefit from accumulated coordinator context (coherence decisions, cross-file awareness) stay in-coordinator and execute sequentially within the wave — rare exception, not default.
 
-2. **Process completions as they arrive.** As each background agent completes:
-   - Verify its output against the spec. Apply `coordinator:verification-before-completion`.
-   - Confirm it stayed within its file footprint (spot-check `git diff --name-only` against the declared footprint).
-   - Commit its changes immediately. Stage everything, brief message.
-   - Mark complete via TaskUpdate.
+2. **Process completions via Haiku verifiers.** As each background executor reports DONE:
+   - Read only the DONE summary file. Do NOT pull the executor's transcript into context.
+   - Dispatch a Haiku verifier with `run_in_background: true` to read the DONE summary + spec + commit diff and write a verdict at `tasks/mise-verify/<item-id>.md` ending with `STATUS: PASS` (or `FOOTPRINT-VIOLATION` | `AC-MISS` | `VERIFICATION-CMD-FAILED` | `NEEDS-EM`). Verifiers are wave-scoped — batch them and gate the wave on all PASS.
+   - On any non-PASS verdict, the EM decides re-dispatch / revert / defer / early-stop from the verdict + diff alone.
+   - Mark complete via TaskUpdate on PASS.
 
 3. **Wave gate:** ALL items in a wave must complete before the next wave begins. This is the serialization point that guarantees later-wave items see earlier-wave changes.
 

--- a/plugins/coordinator/schemas/decision.yaml
+++ b/plugins/coordinator/schemas/decision.yaml
@@ -1,0 +1,14 @@
+schema: decision
+applies_to: "docs/decisions/*.md"
+required:
+  title: string
+  created: iso-date
+  status:
+    type: enum
+    values: [proposed, accepted, deprecated, superseded]
+  deciders:
+    type: list-of-string
+optional:
+  superseded_by: string
+  context: string
+  driver: string

--- a/plugins/coordinator/schemas/handoff.yaml
+++ b/plugins/coordinator/schemas/handoff.yaml
@@ -1,0 +1,16 @@
+schema: handoff
+applies_to: "tasks/handoffs/*.md"
+required:
+  title: string
+  created: iso-date
+  branch: string
+  status:
+    type: enum
+    values: [active, consumed, superseded]
+  predecessor:
+    type: string-or-null
+optional:
+  consumed_by: string
+  consumed_at: iso-date
+  session_goal: string
+  machine: string

--- a/plugins/coordinator/schemas/lesson-entry.yaml
+++ b/plugins/coordinator/schemas/lesson-entry.yaml
@@ -1,0 +1,7 @@
+schema: lesson-entry
+applies_to: "tasks/lessons.md"
+match_mode: inline-tag-per-entry
+entry_pattern: "^\\*\\*[^*]+\\*\\*"
+tag_enum:
+  values: [universal, project]
+  untagged_allowed: true

--- a/plugins/coordinator/schemas/plan.yaml
+++ b/plugins/coordinator/schemas/plan.yaml
@@ -1,0 +1,13 @@
+schema: plan
+applies_to: "docs/plans/*.md"
+required:
+  title: string
+  created: iso-date
+  author: string
+  status:
+    type: enum
+    values: [draft, reviewed, approved, executing, shipped, abandoned]
+optional:
+  branch: string
+  reviewer: string
+  source: string

--- a/plugins/coordinator/schemas/review.yaml
+++ b/plugins/coordinator/schemas/review.yaml
@@ -1,0 +1,15 @@
+schema: review
+applies_to: "tasks/reviews/*.md"
+required:
+  title: string
+  created: iso-date
+  reviewer:
+    type: enum
+    values: [patrik, sid, camelia, pali, fru, zoli]
+  target: string
+  findings_count:
+    type: number
+optional:
+  branch: string
+  commit: string
+  disposition: string

--- a/plugins/coordinator/schemas/worker-run.yaml
+++ b/plugins/coordinator/schemas/worker-run.yaml
@@ -1,0 +1,22 @@
+schema: worker-run
+applies_to: "tasks/worker-runs/*.md"
+required:
+  title: string
+  created: iso-date
+  worker:
+    type: enum
+    values:
+      - test-evidence-parser
+      - security-audit-worker
+      - dep-cve-auditor
+      - doc-link-checker
+      - bp-test-evidence-parser
+      - perf-trace-classifier
+      - schema-migration-auditor
+  target: string
+  findings_count:
+    type: number
+optional:
+  branch: string
+  commit: string
+  run_command: string

--- a/plugins/coordinator/skills/merging-to-main/SKILL.md
+++ b/plugins/coordinator/skills/merging-to-main/SKILL.md
@@ -61,6 +61,12 @@ Before creating a PR, attempt the project's test suite to catch issues early.
    **If on main with unpushed commits ahead of origin/main:**
    These commits need to go through a PR, not be pushed directly. Auto-recover:
    ```bash
+   # Sync-main invariant: verify origin/main is reachable before creating branch.
+   # If local main is ahead of origin/main, abort rather than creating a stale branch.
+   ~/.claude/plugins/coordinator-claude/coordinator/bin/sync-main.sh || {
+     echo "sync-main.sh failed — local main has diverged. Investigate before creating a recovery branch."
+     exit 1
+   }
    # Determine branch name using git-workflow conventions
    BRANCH="work/$(hostname | tr '[:upper:]' '[:lower:]')/$(date +%Y-%m-%d)"
    git checkout -b "$BRANCH"
@@ -213,6 +219,24 @@ This blocks until all checks complete.
 
 ### Step 4: Merge
 
+**Pre-merge quiet check (5-minute activity gate).** Source branches still receiving commits in the last 5 minutes indicate active work that may not belong in this merge. Run before `gh pr merge`:
+
+```bash
+# Get the timestamp of the last commit on the PR's source branch via gh
+last_iso=$(gh pr view "$PR" --json commits -q '.commits[-1].committedDate')
+last=$(python -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$last_iso")
+now=$(python -c "import time; print(int(time.time()))")
+if [ $((now - last)) -lt 300 ]; then
+  branch=$(gh pr view "$PR" --json headRefName -q .headRefName)
+  echo "Source branch $branch has commits younger than 5 minutes — wait for activity to settle, or pass --force-merge-active-branch."
+  exit 1
+fi
+```
+
+**Note:** `gh pr view --json commits` returns commits in chronological order (verified against gh 2.87.3). `.commits[-1]` is the newest commit.
+
+**Override:** If `$ARGUMENTS` contains `--force-merge-active-branch`, skip this gate entirely. Use for deliberate fast merges where the 5-minute window is known-safe.
+
 Use merge commit (not squash) — preserves commit history as breadcrumbs.
 
 ```bash
@@ -285,6 +309,14 @@ If on a worktree: `git worktree remove <path>` instead.
 - **Branch deleted:** {branch} (local + remote)
 - **Now on:** main @ {sha}
 ```
+
+**Other unmerged branches:**
+
+```bash
+~/.claude/plugins/coordinator-claude/coordinator/bin/orphan-branch-sweep.sh --format text --severity-min warning | grep -v "^OK"
+```
+
+If any output: include in the report and recommend: _"Multiple work branches in flight — verify these don't carry work intended for this PR."_
 
 ## Red Flags
 

--- a/plugins/coordinator/skills/merging-to-main/SKILL.md
+++ b/plugins/coordinator/skills/merging-to-main/SKILL.md
@@ -162,7 +162,7 @@ If `coordinator.local.md` declares `project_type` includes `unreal`, run these t
 | Check | Detection | Action |
 |---|---|---|
 | **Plugin version matrix touched?** | Path globs: `control/plugin/**`, `control/server/**`, `.github/workflows/build-plugin-*.yml` (any path match triggers the check) | Verify CI matrix run for all 5 UE versions (5.3–5.7) is green; flag if the diff post-dates the last green CI run |
-| **Structural-index schema bumped?** | Path globs: `mcp_server/structural_index/*.py`, `plugin/holodeck-project-rag/cli.py`, `scripts/download-structural-index.sh`. Content-grep patterns: `MIN_SUPPORTED_SCHEMA`, `authority_version`, `manifest_version` (any path or grep match triggers the check) | Dispatch `schema-migration-auditor` to enumerate downstream readers; require Patrik review of the audit before merge |
+| **Structural-index schema bumped?** | Path globs: `mcp_server/structural_index/*.py`, `project-rag/cli.py`, `scripts/download-structural-index.sh`. Content-grep patterns: `MIN_SUPPORTED_SCHEMA`, `authority_version`, `manifest_version` (any path or grep match triggers the check) | Dispatch `schema-migration-auditor` to enumerate downstream readers; require Patrik review of the audit before merge |
 | **Customer-facing install path touched?** | Path globs: `scripts/install-*.{sh,ps1}`, `scripts/lib/install-shell-utils.{sh,ps1}`, `marketplace.json`, `docs/wiki/holodeck-for-your-ue-project.md` | Verify customer-deployment doc parity (no hardcoded `X:/DroneSim`, no internal-PC assumptions); replay install-shell-utils tests in `tests/install/` |
 
 If `project_type` does not include `unreal`, skip this step entirely.

--- a/plugins/coordinator/skills/using-git-worktrees/SKILL.md
+++ b/plugins/coordinator/skills/using-git-worktrees/SKILL.md
@@ -80,11 +80,15 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 ### 2. Create Worktree
 
 ```bash
+# Sync-main invariant: ensure local main == origin/main before branching.
+~/.claude/plugins/coordinator-claude/coordinator/bin/sync-main.sh
+# If sync-main.sh exits non-zero, stop — do not create a worktree from stale main.
+
 # Determine full path
 path="$LOCATION/$BRANCH_NAME"
 
-# Create worktree with new branch
-git worktree add "$path" -b "$BRANCH_NAME"
+# Create worktree with new branch off the now-current main
+git worktree add "$path" -b "$BRANCH_NAME" main
 cd "$path"
 ```
 

--- a/plugins/coordinator/skills/writing-plans/SKILL.md
+++ b/plugins/coordinator/skills/writing-plans/SKILL.md
@@ -185,6 +185,12 @@ When a plan step dispatches a teammate agent that needs MCP tools, use graduated
 **Graduated resolution order:** `select:exact` → `+prefix` keyword fallback → graceful failure message. Any teammate prompt that names an MCP tool should follow this pattern; hardcoding a single prefix is a silent failure waiting for the next spawn context change.
 
 
+## Lessons Learned
+
+**Default to subagent dispatch over a new RPC verb when *adding* internal operations.** When a plan proposes a new tool/verb/handler/CLI-job, ask first: can a subagent compose this from existing primitives via `execute_python_code` + `inspect` + extant MCP verbs? If yes, the plan should propose the dispatch path, not the new verb. The new verb earns its place only on (a) C++-only capability, (b) transactional state coupling that primitive composition cannot preserve, or (c) cross-call editor-state invisible in tool signatures. **Never default to dispatch over an existing verb without explicit retire-justification** — prior surface is the proven path.
+
+Tag: `[universal]` — applies to any project_type using the coordinator pipeline.
+
 ## Plan Review Gate (Mandatory)
 
 After saving the plan, it MUST go through one review cycle before execution. This catches structural problems while they're cheap to fix — before enrichment and execution invest real work.

--- a/plugins/coordinator/tasks/.deferred-branches.md
+++ b/plugins/coordinator/tasks/.deferred-branches.md
@@ -1,0 +1,22 @@
+# Deferred Branches
+
+Lightweight tracking file managed by `/workday-start` Step 0's Branch Reconciliation Decision flow.
+One line per deferred branch. `/workday-start` Step 1 reads this file alongside the regular
+handoff triage; entries past their re-check date surface as actionable.
+
+## Format
+
+```
+{branch} | reason: {reason} | re-check: {YYYY-MM-DD} | deferred-by: workday-start {YYYY-MM-DD}
+```
+
+## Entries
+
+(empty — no deferred branches)
+
+## Lifecycle
+
+- **Added** when PM selects Option B (defer) during the Branch Reconciliation Decision in Step 0.
+- **Removed** when the branch is consolidated (Option A), archived (Option C), or merged to main.
+- **Surfaced** by `/workday-start` Step 1 when `re-check` date ≤ today.
+- **Auto-added** with `reason=auto-deferred, awaiting PM` in non-interactive (unattended) sessions.

--- a/plugins/game-dev/agents/ue-blueprint-worker.md
+++ b/plugins/game-dev/agents/ue-blueprint-worker.md
@@ -115,7 +115,7 @@ Two extraction scripts produce the **same output schema** as live MCP inspection
 - Output: `bps/batch-NNNN.json` (50 BPs each) + `asset-registry.jsonl` + `referencers.jsonl`.
 - **Best for:** Full project surveys, RAG indexing, any task where you need data from more than ~20 BPs.
 
-### Editor-based extraction (`plugin/holodeck-project-rag/scripts/safe_bp_extract.py`)
+### Editor-based extraction (`project-rag/scripts/safe_bp_extract.py`)
 - Runs via `execute_python_code` inside a live editor session.
 - Checkpointed, one-BP-at-a-time, resumable after editor restarts.
 - **Best for:** Incremental updates when the editor is already open, or when the headless commandlet isn't available.

--- a/tests/plugins/orphan-sweep.test.js
+++ b/tests/plugins/orphan-sweep.test.js
@@ -1,0 +1,307 @@
+// orphan-sweep.test.js — unit tests for bin/orphan-branch-sweep.sh
+//
+// Spec backlink: docs/plans/2026-05-01-orphan-branch-prevention.md § 1.3
+//
+// SCOPE: exercises the three classifier cases (OK, WARNING, CRITICAL) using a
+// temp git repo with planted branches and a stub `gh` binary on PATH.
+//
+// What IS covered:
+//   - work/test/cleanmerged  → merged PR, 0 commits after merge → OK
+//   - work/test/orphaned-after-merge → merged PR, commits after mergedAt → CRITICAL
+//   - work/test/no-pr-stale  → no PR, branch-name date ≥2 days old → WARNING
+//
+// What is NOT covered:
+//   - Live GitHub API calls (gh is stubbed)
+//   - Cross-machine branch detection (out of scope per plan Non-goals)
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execSync, spawnSync } = require('child_process');
+const {
+  PLUGINS_ROOT,
+  mkTempRepo,
+  cleanupTempRepo,
+  mkPathShim,
+} = require('./helpers/fs');
+
+const COORDINATOR_DIR = path.join(PLUGINS_ROOT, 'coordinator-claude', 'coordinator');
+const SWEEP_SCRIPT = path.join(COORDINATOR_DIR, 'bin', 'orphan-branch-sweep.sh');
+
+// ---------------------------------------------------------------------------
+// Bash availability guard
+// ---------------------------------------------------------------------------
+let bashAvailable = false;
+try {
+  const r = spawnSync('bash', ['--version'], { stdio: 'pipe' });
+  bashAvailable = r.status === 0;
+} catch { /* no bash */ }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Back-date a git commit by N seconds relative to now.
+ * Returns the commit timestamp as a Unix epoch string.
+ */
+function backdate(repoPath, branchName, secondsAgo) {
+  const ts = Math.floor(Date.now() / 1000) - secondsAgo;
+  const isoDate = new Date(ts * 1000).toISOString();
+  execSync(`git checkout -q -b ${branchName}`, { cwd: repoPath });
+  fs.writeFileSync(path.join(repoPath, `${branchName.replace(/\//g, '-')}.txt`), `branch ${branchName}`);
+  execSync('git add .', { cwd: repoPath });
+  execSync(`git commit -q --date="${isoDate}" -m "commit on ${branchName}"`, {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: isoDate,
+      GIT_COMMITTER_DATE: isoDate,
+    },
+  });
+  execSync('git checkout -q main', { cwd: repoPath });
+  return ts.toString();
+}
+
+/**
+ * Add additional commits to a branch after a given timestamp (for orphan simulation).
+ */
+function addCommitsAfterDate(repoPath, branchName, afterIso, count) {
+  // Pick a timestamp 60 seconds after afterIso
+  const baseSecs = Math.floor(new Date(afterIso).getTime() / 1000) + 60;
+  execSync(`git checkout -q ${branchName}`, { cwd: repoPath });
+  for (let i = 0; i < count; i++) {
+    const ts = baseSecs + i * 10;
+    const isoDate = new Date(ts * 1000).toISOString();
+    fs.writeFileSync(
+      path.join(repoPath, `orphan-extra-${i}.txt`),
+      `orphan commit ${i}`
+    );
+    execSync('git add .', { cwd: repoPath });
+    execSync(`git commit -q --date="${isoDate}" -m "orphan commit ${i} on ${branchName}"`, {
+      cwd: repoPath,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: isoDate,
+        GIT_COMMITTER_DATE: isoDate,
+      },
+    });
+  }
+  execSync('git checkout -q main', { cwd: repoPath });
+}
+
+// ---------------------------------------------------------------------------
+// Build a gh stub that returns appropriate JSON for each branch
+// ---------------------------------------------------------------------------
+function buildGhStub(shimDir, branchPrMap) {
+  // branchPrMap: { branchName: { number, state, mergedAt } | null }
+  // Write the map to a JSON file; stub reads it at runtime to avoid quoting hell.
+  const mapFile = path.join(shimDir, 'pr-map.json');
+  fs.writeFileSync(mapFile, JSON.stringify(branchPrMap));
+
+  const scriptBody = `#!/usr/bin/env bash
+# stub gh for orphan-sweep tests
+BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --head) BRANCH="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+MAP_FILE="${mapFile.replace(/\\/g, '/')}"
+python3 - "$BRANCH" "$MAP_FILE" <<'PYEOF'
+import json, sys
+branch = sys.argv[1]
+with open(sys.argv[2]) as f:
+    m = json.load(f)
+pr = m.get(branch)
+if pr is None:
+    print('[]')
+else:
+    print(json.dumps([pr]))
+PYEOF
+`;
+  const shimPath = path.join(shimDir, 'gh');
+  fs.writeFileSync(shimPath, scriptBody, { mode: 0o755 });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+describe('orphan-branch-sweep.sh', { skip: !bashAvailable }, () => {
+  let repoPath;
+  let shimDir;
+  let mergedAt;
+
+  before(() => {
+    // 1. Create a temp repo
+    repoPath = mkTempRepo();
+
+    // 2. Plant branches
+    //    a) cleanmerged — branch from main, immediately merged back (ancestor of main tip)
+    execSync('git checkout -q -b work/test/cleanmerged', { cwd: repoPath });
+    // nothing extra — just check it out then merge it into main
+    execSync('git checkout -q main', { cwd: repoPath });
+    execSync('git merge --no-ff -q work/test/cleanmerged -m "merge cleanmerged"', { cwd: repoPath });
+
+    //    b) orphaned-after-merge — create branch, record mergedAt, then add extra commits
+    const staleDate = new Date(Date.now() - 4 * 24 * 3600 * 1000).toISOString();
+    mergedAt = staleDate;
+    backdate(repoPath, 'work/test/orphaned-after-merge', 4 * 24 * 3600 + 100);
+    // Add commits after mergedAt
+    addCommitsAfterDate(repoPath, 'work/test/orphaned-after-merge', mergedAt, 3);
+
+    //    c) no-pr-stale — create with a 3-day-old branch-name date, no PR
+    //    branch name includes a date ≥2 days ago
+    const staleDayStr = new Date(Date.now() - 3 * 24 * 3600 * 1000)
+      .toISOString().split('T')[0]; // YYYY-MM-DD
+    const staleBranchName = `work/testmachine/${staleDayStr}`;
+    backdate(repoPath, staleBranchName, 3 * 24 * 3600);
+
+    // 3. Build gh stub
+    shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-gh-stub-'));
+    buildGhStub(shimDir, {
+      // cleanmerged has a merged PR with no commits after
+      'work/test/cleanmerged': {
+        number: 1,
+        state: 'MERGED',
+        mergedAt: new Date(Date.now() - 5 * 24 * 3600 * 1000).toISOString(),
+        mergeCommit: null,
+      },
+      // orphaned-after-merge has a merged PR but commits exist after mergedAt
+      'work/test/orphaned-after-merge': {
+        number: 2,
+        state: 'MERGED',
+        mergedAt: mergedAt,
+        mergeCommit: null,
+      },
+      // no-pr-stale has no PR (key absent — returns [])
+    });
+  });
+
+  after(() => {
+    cleanupTempRepo(repoPath);
+    if (shimDir) {
+      try { fs.rmSync(shimDir, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  it('script exists and is runnable by bash', () => {
+    assert.ok(fs.existsSync(SWEEP_SCRIPT), `sweep script not found at ${SWEEP_SCRIPT}`);
+    // On Windows, POSIX mode bits via stat are unreliable. Confirm bash can run it.
+    const r = spawnSync('bash', [SWEEP_SCRIPT, '--help'], { encoding: 'utf8' });
+    assert.equal(r.status, 0, `bash could not execute sweep script: ${r.stderr}`);
+  });
+
+  it('exits 0 cleanly with --help', () => {
+    const r = spawnSync('bash', [SWEEP_SCRIPT, '--help'], { encoding: 'utf8' });
+    assert.equal(r.status, 0, `--help exited ${r.status}: ${r.stderr}`);
+    assert.ok(r.stdout.includes('--format'), '--help output missing --format');
+  });
+
+  it('exits 0 outside a git repo (skip-silently contract)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-git-'));
+    try {
+      const r = spawnSync('bash', [SWEEP_SCRIPT], {
+        cwd: tmpDir,
+        encoding: 'utf8',
+      });
+      assert.equal(r.status, 0, `expected exit 0 outside git repo, got ${r.status}`);
+      assert.equal(r.stdout.trim(), '', 'expected no output outside git repo');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('classifies work/test/orphaned-after-merge as CRITICAL', () => {
+    const env = {
+      ...process.env,
+      PATH: `${shimDir}${path.delimiter}${process.env.PATH}`,
+      HOME: repoPath,
+    };
+    const r = spawnSync(
+      'bash',
+      [SWEEP_SCRIPT, '--format', 'json', '--severity-min', 'critical', '--max-age-days', '90'],
+      { cwd: repoPath, encoding: 'utf8', env }
+    );
+    assert.equal(r.status, 0, `sweep exited ${r.status}: ${r.stderr}`);
+    const lines = r.stdout.split('\n').filter(l => l.trim());
+    const critical = lines.filter(l => {
+      try {
+        const obj = JSON.parse(l);
+        return obj.severity === 'CRITICAL' && obj.branch === 'work/test/orphaned-after-merge';
+      } catch { return false; }
+    });
+    assert.ok(critical.length >= 1, `Expected CRITICAL for orphaned-after-merge, got:\n${r.stdout}`);
+  });
+
+  it('classifies the stale no-PR branch as WARNING', () => {
+    const staleDayStr = new Date(Date.now() - 3 * 24 * 3600 * 1000)
+      .toISOString().split('T')[0];
+    const env = {
+      ...process.env,
+      PATH: `${shimDir}${path.delimiter}${process.env.PATH}`,
+      HOME: repoPath,
+    };
+    const r = spawnSync(
+      'bash',
+      [SWEEP_SCRIPT, '--format', 'json', '--severity-min', 'warning', '--max-age-days', '90'],
+      { cwd: repoPath, encoding: 'utf8', env }
+    );
+    assert.equal(r.status, 0, `sweep exited ${r.status}: ${r.stderr}`);
+    const lines = r.stdout.split('\n').filter(l => l.trim());
+    const warnings = lines.filter(l => {
+      try {
+        const obj = JSON.parse(l);
+        return obj.severity === 'WARNING' && obj.branch.includes(staleDayStr);
+      } catch { return false; }
+    });
+    assert.ok(warnings.length >= 1, `Expected WARNING for stale no-PR branch (${staleDayStr}), got:\n${r.stdout}`);
+  });
+
+  it('--severity-min critical suppresses WARNING entries', () => {
+    const env = {
+      ...process.env,
+      PATH: `${shimDir}${path.delimiter}${process.env.PATH}`,
+      HOME: repoPath,
+    };
+    const r = spawnSync(
+      'bash',
+      [SWEEP_SCRIPT, '--format', 'json', '--severity-min', 'critical', '--max-age-days', '90'],
+      { cwd: repoPath, encoding: 'utf8', env }
+    );
+    assert.equal(r.status, 0);
+    const lines = r.stdout.split('\n').filter(l => l.trim());
+    const warnings = lines.filter(l => {
+      try { return JSON.parse(l).severity === 'WARNING'; } catch { return false; }
+    });
+    assert.equal(warnings.length, 0, `--severity-min critical should suppress WARNINGs, got: ${r.stdout}`);
+  });
+
+  it('text format emits readable lines', () => {
+    const env = {
+      ...process.env,
+      PATH: `${shimDir}${path.delimiter}${process.env.PATH}`,
+      HOME: repoPath,
+    };
+    const r = spawnSync(
+      'bash',
+      [SWEEP_SCRIPT, '--format', 'text', '--severity-min', 'warning', '--max-age-days', '90'],
+      { cwd: repoPath, encoding: 'utf8', env }
+    );
+    assert.equal(r.status, 0, `sweep exited ${r.status}: ${r.stderr}`);
+    // Lines should start with CRITICAL or WARNING
+    const lines = r.stdout.split('\n').filter(l => l.trim());
+    assert.ok(lines.length >= 1, 'Expected at least one output line in text format');
+    for (const line of lines) {
+      assert.ok(
+        line.startsWith('CRITICAL') || line.startsWith('WARNING') || line.startsWith('OK'),
+        `Unexpected text format line: ${line}`
+      );
+    }
+  });
+});

--- a/tests/plugins/run.js
+++ b/tests/plugins/run.js
@@ -1,7 +1,13 @@
-// Plugin Infrastructure Test Suite for coordinator-claude
-// Run: node --test tests/plugins/run.js
+// Plugin Infrastructure Test Suite
+// Run: node --test ~/.claude/tests/plugins/run.js
 require('./marketplace.test.js');
 require('./plugin-structure.test.js');
+require('./references.test.js');
 require('./frontmatter.test.js');
 require('./hooks.test.js');
+require('./hooks-behavior.test.js');
 require('./mcp-config.test.js');
+require('./installed-state.test.js');
+require('./pipeline-templates.test.js');
+require('./coordinator-degradation.test.js');
+require('./orphan-sweep.test.js');


### PR DESCRIPTION
## v1.7.0 — 2026-05-01

### Theme — Portable Ideas from Obsidian (W1+W2+W3)

Three workstreams percolated from `~/.claude` HEAD as a single bundle (R2 APPROVED_WITH_NOTES, all 7 findings integrated). Schemas + lint belt, live-query primitives, and tiered context-loading doctrine. Also includes v1.6.0 orphan-branch-prevention sync from PR #57.

### Added
- **W1** — Frontmatter schemas + lint belt + PreToolUse validator (WARN mode by default).
- **W2** — Live queries CLI (`bin/query-records`) + sentinel-block primitives + `refresh-queries` for `<!-- BEGIN query -->` callouts.
- **W3** — Tiered context loading doctrine (`docs/wiki/tiered-context-loading.md`) + telemetry (`track-tier-usage.sh`) + tier-4 rationale rule.
- **Orphan-branch prevention** (v1.6.0) — `orphan-branch-sweep.sh`, `sync-main.sh`, `check-shipped-on-main.sh`, workday-start Step 0/0.5, gh-merge prohibitions in doc-maintenance dispatch prompts.

### Changed
- Doctrine + preamble syncs across `CLAUDE.md`, `agents/staff-eng`, and commands `{distill, handoff, mise-en-place, session-start, session-end, update-docs}`.

### Internal
- Test coverage for `schema.js`, `query-records`, `sentinel-blocks`, `orphan-sweep`.

---

<details>
<summary>Commit log</summary>

8f1537a docs(changelog): v1.7.0 — obsidian portable-ideas borrows (W1+W2+W3)
9ea8672 sync: obsidian portable-ideas borrows (W1+W2+W3 + R1+R2 integration)
8ac6c06 borrows: bin/lib/schema.js (lessons validator with code-span/link-text robustness)
c0c4ee6 docs(changelog): v1.6.0 — orphan-branch-prevention
9f2e0d2 sync: orphan-branch-prevention from source repo (PR #57)

</details>